### PR TITLE
feat(react): disallow the use of TypeScript enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ module.exports = {
 };
 ```
 
-This shared ESLint configuration is specifically tailored for [React](https://reactjs.org/) projects, and extends `@boehringer-ingelheim/eslint-config/base`. It uses the browser environment, and includes recommended configurations for the following plugins: jsx-a11y, react, and react-hooks.
+This shared ESLint configuration is specifically tailored for [React](https://reactjs.org/) projects, and extends `@boehringer-ingelheim/eslint-config/base`. It uses the browser environment, and includes recommended configurations for the following plugins:
 
 - [`eslint-plugin-jsx-a11y`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y)
 - [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react)
 - [`eslint-plugin-react-hooks`](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks)
+- [`eslint-plugin-typescript-enum`](https://github.com/shian15810/eslint-plugin-typescript-enum)
 
 The configuration sets several custom rules, including `@typescript-eslint/ban-types` and `@typescript-eslint/consistent-type-definitions`, as well as rules for organizing and formatting import statements.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-sonarjs": "^0.18.0",
-        "eslint-plugin-sort-keys-plus": "^1.3.1"
+        "eslint-plugin-sort-keys-plus": "^1.3.1",
+        "eslint-plugin-typescript-enum": "^2.1.0"
       },
       "devDependencies": {
         "@boehringer-ingelheim/prettier-config": "1.0.0",
@@ -1025,6 +1026,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.52.0.tgz",
+      "integrity": "sha512-kd8CRr04mNE3hw4et6+0T0NI5vli2H6dJCGzjX1r12s/FXUehLVadmvo2Nl3DN80YqAh1cVC6zYZAkpmGiVJ5g==",
+      "dependencies": {
+        "@typescript-eslint/utils": "5.52.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2680,6 +2699,14 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/eslint-plugin-typescript-enum": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-enum/-/eslint-plugin-typescript-enum-2.1.0.tgz",
+      "integrity": "sha512-n6RO89KJ2V2nHVAdIq1q3IBeYZSNZjBreqXOzpjmsBtw+NNhSTTSQXqwO00VYOce9Gy8cr2cDEYpj0Km+Ij90Q==",
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.3.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -8993,7 +9020,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -10251,6 +10279,14 @@
         "tsutils": "^3.21.0"
       }
     },
+    "@typescript-eslint/experimental-utils": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.52.0.tgz",
+      "integrity": "sha512-kd8CRr04mNE3hw4et6+0T0NI5vli2H6dJCGzjX1r12s/FXUehLVadmvo2Nl3DN80YqAh1cVC6zYZAkpmGiVJ5g==",
+      "requires": {
+        "@typescript-eslint/utils": "5.52.0"
+      }
+    },
     "@typescript-eslint/parser": {
       "version": "5.52.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz",
@@ -11474,6 +11510,14 @@
       "requires": {
         "escape-string-regexp": "^4.0.0",
         "natural-compare": "^1.4.0"
+      }
+    },
+    "eslint-plugin-typescript-enum": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-typescript-enum/-/eslint-plugin-typescript-enum-2.1.0.tgz",
+      "integrity": "sha512-n6RO89KJ2V2nHVAdIq1q3IBeYZSNZjBreqXOzpjmsBtw+NNhSTTSQXqwO00VYOce9Gy8cr2cDEYpj0Km+Ij90Q==",
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.3.0"
       }
     },
     "eslint-scope": {
@@ -15913,7 +15957,8 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "peer": true
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-sonarjs": "^0.18.0",
-    "eslint-plugin-sort-keys-plus": "^1.3.1"
+    "eslint-plugin-sort-keys-plus": "^1.3.1",
+    "eslint-plugin-typescript-enum": "^2.1.0"
   },
   "devDependencies": {
     "@boehringer-ingelheim/prettier-config": "1.0.0",

--- a/react/index.js
+++ b/react/index.js
@@ -9,7 +9,13 @@ module.exports = {
   env: {
     browser: true,
   },
-  extends: ["../base/index.js", "plugin:jsx-a11y/recommended", "plugin:react/recommended", "plugin:react/jsx-runtime"],
+  extends: [
+    "../base/index.js",
+    "plugin:jsx-a11y/recommended",
+    "plugin:react/recommended",
+    "plugin:react/jsx-runtime",
+    "plugin:typescript-enum/recommended",
+  ],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
@@ -17,7 +23,7 @@ module.exports = {
     ecmaVersion: "latest",
     sourceType: "module",
   },
-  plugins: ["jsx-a11y", "react", "react-hooks"],
+  plugins: ["jsx-a11y", "react", "react-hooks", "typescript-enum"],
   rules: {
     // @typescript-eslint: https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin/docs/rules
     "@typescript-eslint/ban-types": [


### PR DESCRIPTION
- install package `eslint-plugin-typescript-enum@2.1.0`
- extend react configuration with `typescript-enum/recommended`
- update documentation