### PR TITLE
fix(eslint-plugin): [import/no-unused-modules] ignore rule on specified files

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -17,6 +17,18 @@ module.exports = {
     "plugin:import/typescript",
     "plugin:sonarjs/recommended",
   ],
+  overrides: [
+    {
+      files: [
+        "**/*.d.ts", // TypeScript declaration files
+        "**/*.{spec,test}.*", // Usually test files
+        "*.{js,ts}", // Mostly configuration files
+      ],
+      rules: {
+        "import/no-unused-modules": "off",
+      },
+    },
+  ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: "./tsconfig.json",


### PR DESCRIPTION
By default, the [`import/no-unused-modules`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unused-modules.md#importno-unused-modules) rule is used to indicate missing and unused exports. However, this is not necessary for all files and it comes to positive false reports. With appropriate adjustments this rule is switched off for certain files.