### PR TITLE
fix(eslint-plugin): [parserOptions] improve monorepo support

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -31,7 +31,8 @@ module.exports = {
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    project: "./tsconfig.json",
+    // find the tsconfig.json nearest each source file
+    project: true,
   },
   plugins: ["@typescript-eslint", "sonarjs", "sort-keys-plus"],
   rules: {


### PR DESCRIPTION
- use the tsconfig.json nearest each source file