### PR TITLE
feat: add eslint-plugin-perfectionist

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,21 +4,14 @@ module.exports = {
     es2022: true,
     node: true,
   },
-  extends: ["eslint:recommended"],
-  plugins: ["sort-keys-plus"],
+  extends: ["eslint:recommended", "plugin:perfectionist/recommended-natural"],
   rules: {
-    /**
-     * Required to fix sort-keys automatically, since this is not done by default.
-     * See: https://github.com/forivall/eslint-plugin-sort-keys-plus
-     */
-    "sort-keys-plus/sort-keys": [
+    "perfectionist/sort-objects": [
       "error",
-      "asc",
       {
-        allowLineSeparatedGroups: true,
-        caseSensitive: false,
-        natural: true,
+        "partition-by-comment": true,
       },
     ],
+    "sort-keys": "off", // disabled due to conflict with eslint-plugin-perfectionist
   },
 };

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The following plugins are used in this configuration:
 - [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import)
 - [`eslint-plugin-sonarjs`](https://github.com/SonarSource/eslint-plugin-sonarjs)
 
-Additionally, the [`eslint-plugin-sort-keys-plus`](https://github.com/forivall/eslint-plugin-sort-keys-plus) is used to automatically fix sorting issues.
+Additionally, the [`eslint-plugin-perfectionist`](https://github.com/azat-io/eslint-plugin-perfectionist) is used to automatically fix sorting issues.
 
 This configuration also sets up the TypeScript parser [`@typescript-eslint/parser`](https://typescript-eslint.io/architecture/parser) and [`eslint-import-resolver-typescript`](https://github.com/import-js/eslint-import-resolver-typescript). The TypeScript project file `./tsconfig.json` is set as default value for the project option in the parser configuration. If this is not the case, this must be changed accordingly:
 

--- a/base/index.js
+++ b/base/index.js
@@ -98,7 +98,6 @@ module.exports = {
       "error",
       {
         "newlines-between": "ignore",
-        "read-tsconfig": true,
       },
     ],
     "perfectionist/sort-objects": [

--- a/base/index.js
+++ b/base/index.js
@@ -15,6 +15,7 @@ module.exports = {
     "plugin:@typescript-eslint/stylistic-type-checked",
     "plugin:import/recommended",
     "plugin:import/typescript",
+    "plugin:perfectionist/recommended-natural",
     "plugin:sonarjs/recommended",
   ],
   overrides: [
@@ -34,9 +35,10 @@ module.exports = {
     // find the tsconfig.json nearest each source file
     project: true,
   },
-  plugins: ["@typescript-eslint", "sonarjs", "sort-keys-plus"],
+  plugins: ["@typescript-eslint", "sonarjs"],
   rules: {
     // @typescript-eslint: https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin/docs/rules
+    "@typescript-eslint/adjacent-overload-signatures": "off", // disabled due to conflict with eslint-plugin-perfectionist
     "@typescript-eslint/no-floating-promises": ["error", { ignoreVoid: true }],
     "@typescript-eslint/no-misused-promises": [
       "error",
@@ -52,7 +54,7 @@ module.exports = {
         varsIgnorePattern: "^_",
       },
     ],
-    "@typescript-eslint/sort-type-constituents": "error",
+    "@typescript-eslint/sort-type-constituents": "off", // disabled due to conflict with eslint-plugin-perfectionist
 
     // eslint: https://github.com/eslint/eslint/tree/main/lib/rules
     "arrow-body-style": ["error", "as-needed"],
@@ -75,6 +77,8 @@ module.exports = {
     "prefer-const": "error",
     "prefer-rest-params": "error",
     "prefer-template": "error",
+    "sort-imports": "off", // disabled due to conflict with eslint-plugin-perfectionist
+    "sort-keys": "off", // disabled due to conflict with eslint-plugin-perfectionist
 
     // eslint-plugin-import: https://github.com/import-js/eslint-plugin-import/tree/main/docs/rules
     "import/no-cycle": "error",
@@ -86,28 +90,21 @@ module.exports = {
         unusedExports: true,
       },
     ],
-    "import/order": [
-      "error",
-      {
-        alphabetize: {
-          caseInsensitive: true,
-          order: "asc",
-          orderImportKind: "asc",
-        },
-      },
-    ],
+    "import/order": "off", // disabled due to conflict with eslint-plugin-perfectionist
     "import/prefer-default-export": "off",
 
-    /**
-     * Required to fix sort-keys automatically, since this is not done by default.
-     * See: https://github.com/forivall/eslint-plugin-sort-keys-plus
-     */
-    "sort-keys-plus/sort-keys": [
+    // eslint-plugin-perfectionist: https://github.com/azat-io/eslint-plugin-perfectionist
+    "perfectionist/sort-imports": [
       "error",
-      "asc",
       {
-        caseSensitive: false,
-        natural: true,
+        "newlines-between": "ignore",
+        "read-tsconfig": true,
+      },
+    ],
+    "perfectionist/sort-objects": [
+      "error",
+      {
+        "partition-by-comment": true,
       },
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
         "eslint-import-resolver-typescript": "^3.6.0",
         "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-perfectionist": "^1.5.1",
         "eslint-plugin-playwright": "^0.15.3",
         "eslint-plugin-react": "^7.33.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-sonarjs": "^0.20.0",
-        "eslint-plugin-sort-keys-plus": "^1.3.1",
         "eslint-plugin-typescript-enum": "^2.1.0"
       },
       "devDependencies": {
@@ -3105,6 +3105,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3327,6 +3328,170 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-perfectionist": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-1.5.1.tgz",
+      "integrity": "sha512-PiUrAfGDc/l6MKKUP8qt5RXueC7FZC6F/0j8ijXYU8o3x8o2qUi6zEEYBkId/IiKloIXM5KTD4jrH9833kDNzA==",
+      "dependencies": {
+        "@typescript-eslint/types": "^5.62.0",
+        "@typescript-eslint/utils": "^5.62.0",
+        "is-core-module": "^2.12.1",
+        "json5": "^2.2.3",
+        "minimatch": "^9.0.3",
+        "natural-compare-lite": "^1.4.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-plugin-playwright": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
@@ -3424,18 +3589,6 @@
       },
       "peerDependencies": {
         "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-sort-keys-plus": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-keys-plus/-/eslint-plugin-sort-keys-plus-1.3.1.tgz",
-      "integrity": "sha512-1z92UqTCSB714kTt+nhLdvuqc6LPnFW91vwrKdYPw2dBnxxWmcssnqR5CDN3BIfsQ2YUTXXLpmLZ5lq4zT7rkw==",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "natural-compare": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/eslint-plugin-typescript-enum": {
@@ -3773,7 +3926,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "peer": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -3922,6 +4076,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4273,6 +4428,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -8690,6 +8846,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10229,7 +10386,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -12897,7 +13055,8 @@
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "peer": true
     },
     "eslint": {
       "version": "8.47.0",
@@ -13094,6 +13253,108 @@
         }
       }
     },
+    "eslint-plugin-perfectionist": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-1.5.1.tgz",
+      "integrity": "sha512-PiUrAfGDc/l6MKKUP8qt5RXueC7FZC6F/0j8ijXYU8o3x8o2qUi6zEEYBkId/IiKloIXM5KTD4jrH9833kDNzA==",
+      "requires": {
+        "@typescript-eslint/types": "^5.62.0",
+        "@typescript-eslint/utils": "^5.62.0",
+        "is-core-module": "^2.12.1",
+        "json5": "^2.2.3",
+        "minimatch": "^9.0.3",
+        "natural-compare-lite": "^1.4.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+          "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+          "requires": {
+            "@typescript-eslint/types": "5.62.0",
+            "@typescript-eslint/visitor-keys": "5.62.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+          "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ=="
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+          "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+          "requires": {
+            "@typescript-eslint/types": "5.62.0",
+            "@typescript-eslint/visitor-keys": "5.62.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+          "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+          "requires": {
+            "@eslint-community/eslint-utils": "^4.2.0",
+            "@types/json-schema": "^7.0.9",
+            "@types/semver": "^7.3.12",
+            "@typescript-eslint/scope-manager": "5.62.0",
+            "@typescript-eslint/types": "5.62.0",
+            "@typescript-eslint/typescript-estree": "5.62.0",
+            "eslint-scope": "^5.1.1",
+            "semver": "^7.3.7"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.62.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+          "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+          "requires": {
+            "@typescript-eslint/types": "5.62.0",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        },
+        "json5": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "eslint-plugin-playwright": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
@@ -13158,15 +13419,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.20.0.tgz",
       "integrity": "sha512-BRhZ7BY/oTr6DDaxvx58ReTg7R+J8T+Y2ZVGgShgpml25IHBTIG7EudUtHuJD1zhtMgUEt59x3VNvUQRo2LV6w==",
       "requires": {}
-    },
-    "eslint-plugin-sort-keys-plus": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-keys-plus/-/eslint-plugin-sort-keys-plus-1.3.1.tgz",
-      "integrity": "sha512-1z92UqTCSB714kTt+nhLdvuqc6LPnFW91vwrKdYPw2dBnxxWmcssnqR5CDN3BIfsQ2YUTXXLpmLZ5lq4zT7rkw==",
-      "requires": {
-        "escape-string-regexp": "^4.0.0",
-        "natural-compare": "^1.4.0"
-      }
     },
     "eslint-plugin-typescript-enum": {
       "version": "2.1.0",
@@ -13400,7 +13652,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "peer": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -13515,6 +13768,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "peer": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13743,6 +13997,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "peer": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -16765,7 +17020,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "peer": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -17858,7 +18114,8 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "peer": true
     },
     "through": {
       "version": "2.3.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eslint-import-resolver-typescript": "^3.6.0",
         "eslint-plugin-import": "^2.28.0",
         "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-perfectionist": "^1.5.1",
+        "eslint-plugin-perfectionist": "^2.1.0",
         "eslint-plugin-playwright": "^0.15.3",
         "eslint-plugin-react": "^7.33.1",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -3329,31 +3329,46 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-1.5.1.tgz",
-      "integrity": "sha512-PiUrAfGDc/l6MKKUP8qt5RXueC7FZC6F/0j8ijXYU8o3x8o2qUi6zEEYBkId/IiKloIXM5KTD4jrH9833kDNzA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.1.0.tgz",
+      "integrity": "sha512-KVA7H6J/qfmZH/WopNKFgYbKoX+ozKAOIeQvo/+jibn6k9e71Et+giIHEHrMICZ043CeGpRKrCRRhlmD7pjeRg==",
       "dependencies": {
-        "@typescript-eslint/types": "^5.62.0",
-        "@typescript-eslint/utils": "^5.62.0",
-        "is-core-module": "^2.12.1",
-        "json5": "^2.2.3",
+        "@typescript-eslint/utils": "^6.6.0",
         "minimatch": "^9.0.3",
         "natural-compare-lite": "^1.4.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.0.0"
+        "astro-eslint-parser": "^0.14.0",
+        "eslint": ">=8.0.0",
+        "svelte": ">=3.0.0",
+        "svelte-eslint-parser": "^0.32.0",
+        "vue-eslint-parser": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "astro-eslint-parser": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "svelte-eslint-parser": {
+          "optional": true
+        },
+        "vue-eslint-parser": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz",
+      "integrity": "sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==",
       "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0"
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3361,11 +3376,11 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/types": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.0.tgz",
+      "integrity": "sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q==",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3373,20 +3388,20 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz",
+      "integrity": "sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==",
       "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/visitor-keys": "6.7.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3399,40 +3414,39 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.0.tgz",
+      "integrity": "sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.7.0",
+        "@typescript-eslint/types": "6.7.0",
+        "@typescript-eslint/typescript-estree": "6.7.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz",
+      "integrity": "sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==",
       "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "6.7.0",
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3445,37 +3459,6 @@
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-perfectionist/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-perfectionist/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-plugin-perfectionist/node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eslint-plugin-perfectionist/node_modules/minimatch": {
@@ -13254,68 +13237,64 @@
       }
     },
     "eslint-plugin-perfectionist": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-1.5.1.tgz",
-      "integrity": "sha512-PiUrAfGDc/l6MKKUP8qt5RXueC7FZC6F/0j8ijXYU8o3x8o2qUi6zEEYBkId/IiKloIXM5KTD4jrH9833kDNzA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.1.0.tgz",
+      "integrity": "sha512-KVA7H6J/qfmZH/WopNKFgYbKoX+ozKAOIeQvo/+jibn6k9e71Et+giIHEHrMICZ043CeGpRKrCRRhlmD7pjeRg==",
       "requires": {
-        "@typescript-eslint/types": "^5.62.0",
-        "@typescript-eslint/utils": "^5.62.0",
-        "is-core-module": "^2.12.1",
-        "json5": "^2.2.3",
+        "@typescript-eslint/utils": "^6.6.0",
         "minimatch": "^9.0.3",
         "natural-compare-lite": "^1.4.0"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "5.62.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-          "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.0.tgz",
+          "integrity": "sha512-lAT1Uau20lQyjoLUQ5FUMSX/dS07qux9rYd5FGzKz/Kf8W8ccuvMyldb8hadHdK/qOI7aikvQWqulnEq2nCEYA==",
           "requires": {
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/visitor-keys": "5.62.0"
+            "@typescript-eslint/types": "6.7.0",
+            "@typescript-eslint/visitor-keys": "6.7.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.62.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-          "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ=="
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.0.tgz",
+          "integrity": "sha512-ihPfvOp7pOcN/ysoj0RpBPOx3HQTJTrIN8UZK+WFd3/iDeFHHqeyYxa4hQk4rMhsz9H9mXpR61IzwlBVGXtl9Q=="
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.62.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-          "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.0.tgz",
+          "integrity": "sha512-dPvkXj3n6e9yd/0LfojNU8VMUGHWiLuBZvbM6V6QYD+2qxqInE7J+J/ieY2iGwR9ivf/R/haWGkIj04WVUeiSQ==",
           "requires": {
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/visitor-keys": "5.62.0",
+            "@typescript-eslint/types": "6.7.0",
+            "@typescript-eslint/visitor-keys": "6.7.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
           }
         },
         "@typescript-eslint/utils": {
-          "version": "5.62.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-          "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.0.tgz",
+          "integrity": "sha512-MfCq3cM0vh2slSikQYqK2Gq52gvOhe57vD2RM3V4gQRZYX4rDPnKLu5p6cm89+LJiGlwEXU8hkYxhqqEC/V3qA==",
           "requires": {
-            "@eslint-community/eslint-utils": "^4.2.0",
-            "@types/json-schema": "^7.0.9",
-            "@types/semver": "^7.3.12",
-            "@typescript-eslint/scope-manager": "5.62.0",
-            "@typescript-eslint/types": "5.62.0",
-            "@typescript-eslint/typescript-estree": "5.62.0",
-            "eslint-scope": "^5.1.1",
-            "semver": "^7.3.7"
+            "@eslint-community/eslint-utils": "^4.4.0",
+            "@types/json-schema": "^7.0.12",
+            "@types/semver": "^7.5.0",
+            "@typescript-eslint/scope-manager": "6.7.0",
+            "@typescript-eslint/types": "6.7.0",
+            "@typescript-eslint/typescript-estree": "6.7.0",
+            "semver": "^7.5.4"
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.62.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-          "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.0.tgz",
+          "integrity": "sha512-/C1RVgKFDmGMcVGeD8HjKv2bd72oI1KxQDeY8uc66gw9R0OK0eMq48cA+jv9/2Ag6cdrsUGySm1yzYmfz0hxwQ==",
           "requires": {
-            "@typescript-eslint/types": "5.62.0",
-            "eslint-visitor-keys": "^3.3.0"
+            "@typescript-eslint/types": "6.7.0",
+            "eslint-visitor-keys": "^3.4.1"
           }
         },
         "brace-expansion": {
@@ -13325,25 +13304,6 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
-        },
-        "eslint-scope": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-          "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-          "requires": {
-            "esrecurse": "^4.3.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
-        },
-        "json5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-          "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
         },
         "minimatch": {
           "version": "9.0.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-import-resolver-typescript": "^3.6.0",
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-perfectionist": "^1.5.1",
+    "eslint-plugin-perfectionist": "^2.1.0",
     "eslint-plugin-playwright": "^0.15.3",
     "eslint-plugin-react": "^7.33.1",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "eslint-import-resolver-typescript": "^3.6.0",
     "eslint-plugin-import": "^2.28.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-perfectionist": "^1.5.1",
     "eslint-plugin-playwright": "^0.15.3",
     "eslint-plugin-react": "^7.33.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-sonarjs": "^0.20.0",
-    "eslint-plugin-sort-keys-plus": "^1.3.1",
     "eslint-plugin-typescript-enum": "^2.1.0"
   },
   "devDependencies": {

--- a/react/index.js
+++ b/react/index.js
@@ -43,44 +43,51 @@ module.exports = {
     ],
     "@typescript-eslint/consistent-type-definitions": ["error", "type"],
 
-    // eslint-plugin-import: https://github.com/import-js/eslint-plugin-import/tree/main/docs/rules
-    "import/order": [
-      "error",
-      {
-        alphabetize: {
-          caseInsensitive: true,
-          order: "asc",
-          orderImportKind: "asc",
-        },
-        pathGroups: [
-          {
-            group: "external",
-            pattern: "react",
-            position: "before",
-          },
-        ],
-        pathGroupsExcludedImportTypes: ["react"],
-      },
-    ],
-
     // eslint-plugin-react: https://github.com/jsx-eslint/eslint-plugin-react/tree/master/lib/rules
     "react/jsx-pascal-case": "error",
-    "react/jsx-sort-props": [
-      "error",
-      {
-        callbacksLast: true,
-        ignoreCase: true,
-        noSortAlphabetically: false,
-        reservedFirst: true,
-        shorthandFirst: false,
-        shorthandLast: false,
-      },
-    ],
+    "react/jsx-sort-props": "off", // disabled due to conflict with eslint-plugin-perfectionist
     "react/sort-default-props": "error",
 
     // eslint-plugin-react-hooks: https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md
     "react-hooks/exhaustive-deps": "error",
     "react-hooks/rules-of-hooks": "error",
+
+    // eslint-plugin-perfectionist: https://github.com/azat-io/eslint-plugin-perfectionist
+    "perfectionist/sort-imports": [
+      "error",
+      {
+        "custom-groups": {
+          type: {
+            react: ["react"],
+          },
+          value: {
+            react: ["react"],
+          },
+        },
+        groups: [
+          "react",
+          // Groups from shared config: https://eslint-plugin-perfectionist.azat.io/rules/sort-imports#groups
+          "type",
+          ["builtin", "external"],
+          "internal-type",
+          "internal",
+          ["parent-type", "sibling-type", "index-type"],
+          ["parent", "sibling", "index"],
+          "object",
+          "unknown",
+        ],
+        "newlines-between": "ignore",
+        "read-tsconfig": true,
+      },
+    ],
+    "perfectionist/sort-jsx-props": [
+      "error",
+      {
+        // Reserved props from: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-sort-props.js#L40C12-L40C12
+        "always-on-top": ["children", "dangerouslySetInnerHTML", "key", "ref"],
+        callback: "last",
+      },
+    ],
   },
   settings: {
     react: {

--- a/react/index.js
+++ b/react/index.js
@@ -77,15 +77,16 @@ module.exports = {
           "unknown",
         ],
         "newlines-between": "ignore",
-        "read-tsconfig": true,
       },
     ],
     "perfectionist/sort-jsx-props": [
       "error",
       {
-        // Reserved props from: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-sort-props.js#L40C12-L40C12
-        "always-on-top": ["children", "dangerouslySetInnerHTML", "key", "ref"],
-        callback: "last",
+        "custom-groups": {
+          callback: "on*",
+          reservedProps: ["children", "dangerouslySetInnerHTML", "key", "ref"], // Reserved props from: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-sort-props.js#L40C12-L40C12
+        },
+        groups: ["reservedProps", "unknown", "callback"],
       },
     ],
   },


### PR DESCRIPTION
- add eslint-plugin-perfectionist
- remove eslint-plugin-sort-keys-plus
- disable the following rules in favor of eslint-plugin-perfectionist
  - import/order
  - sort-imports
  - @typescript-eslint/adjacent-overload-signatures
  - sort-keys
  - @typescript-eslint/sort-type-constituents
- activate rulset perfectionist/recommended-natural
- configure perfectionist/sort-imports similar as import/order before
- configure perfectionist/sort-jsx-props similar as react/jsx-sort-props before

BREAKING CHANGE: add eslint-plugin-perfectionist and remove eslint-plugin-sort-keys-plus