### PR TITLE
ci(github): update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - next
+
 jobs:
   release:
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,18 @@ jobs:
       # Disable husky (git hooks) in CI, see: https://typicode.github.io/husky/#/?id=disable-husky-in-cidocker
       HUSKY: 0
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
           registry-url: https://registry.npmjs.org/
           cache: npm
       - name: Install Dependencies
-        run: npm ci
+        run: npm clean-install
       - name: Release package to npm and GitHub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- update runner-image to `ubuntu-22.04`
- support `next` as pre-release