### PR TITLE
build(npm): fix missing lib module

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "files": [
     "base",
+    "lib",
     "react",
     "playwright"
   ],


### PR DESCRIPTION
- include `lib` folder into publishing files