### PR TITLE
Reenable recommended groups configuration of perfectionist/sort-classes

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -1,4 +1,4 @@
-const { SORT_IMPORTS_GROUPS } = require("../lib/eslint-plugin-perfectionist");
+const { SORT_CLASSES_GROUPS, SORT_IMPORTS_GROUPS } = require("../lib/eslint-plugin-perfectionist");
 
 /**
  * Workaround to allow ESLint to resolve plugins that were installed
@@ -104,7 +104,7 @@ module.exports = {
     // eslint-plugin-perfectionist: https://github.com/azat-io/eslint-plugin-perfectionist
     "perfectionist/sort-array-includes": ["error", { "ignore-case": true, type: "natural" }],
     "perfectionist/sort-astro-attributes": ["error", { "ignore-case": true, type: "natural" }],
-    "perfectionist/sort-classes": ["error", { "ignore-case": true, type: "natural" }],
+    "perfectionist/sort-classes": ["error", { groups: SORT_CLASSES_GROUPS, "ignore-case": true, type: "natural" }],
     "perfectionist/sort-enums": ["error", { "ignore-case": true, type: "natural" }],
     "perfectionist/sort-exports": ["error", { "ignore-case": true, type: "natural" }],
     "perfectionist/sort-imports": [

--- a/lib/eslint-plugin-perfectionist.js
+++ b/lib/eslint-plugin-perfectionist.js
@@ -14,6 +14,28 @@ const SORT_IMPORTS_GROUPS = [
   "unknown",
 ];
 
+/**
+ * This is the the groups configuration of all the recommended configs by eslint-plugin-perfectionist.
+ * This array can be used to reconfigure some options of the perfectionist/sort-classes rule without
+ * overwriting the groups configuration of this rule.
+ * This config can be found here:
+ * - https://eslint-plugin-perfectionist.azat.io/rules/sort-classes#groups
+ * - https://github.com/azat-io/eslint-plugin-perfectionist/blob/main/index.ts#L61
+ */
+const SORT_CLASSES_GROUPS = [
+  "index-signature",
+  "static-property",
+  "private-property",
+  "property",
+  "constructor",
+  "static-method",
+  "private-method",
+  "method",
+  ["get-method", "set-method"],
+  "unknown",
+];
+
 module.exports = {
+  SORT_CLASSES_GROUPS,
   SORT_IMPORTS_GROUPS,
 };


### PR DESCRIPTION
In PR #16 we introduced some custom configurations for perfectionist/sort-classes. These configurations also overwrite the groups configuration which was not intended.