### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/eslint-patch": "^1.5.1",
-        "@typescript-eslint/eslint-plugin": "^6.10.0",
-        "@typescript-eslint/parser": "^6.10.0",
+        "@rushstack/eslint-patch": "^1.6.0",
+        "@typescript-eslint/eslint-plugin": "^6.12.0",
+        "@typescript-eslint/parser": "^6.12.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-jsx-a11y": "^6.8.0",
-        "eslint-plugin-perfectionist": "^2.2.0",
+        "eslint-plugin-perfectionist": "^2.4.0",
         "eslint-plugin-playwright": "^0.18.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -25,15 +25,15 @@
       },
       "devDependencies": {
         "@boehringer-ingelheim/prettier-config": "1.0.0",
-        "@commitlint/cli": "18.2.0",
-        "@commitlint/config-conventional": "18.1.0",
-        "@commitlint/types": "18.1.0",
+        "@commitlint/cli": "18.4.3",
+        "@commitlint/config-conventional": "18.4.3",
+        "@commitlint/types": "18.4.3",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "dotenv-cli": "7.3.0",
         "husky": "8.0.3",
-        "prettier": "3.0.3",
-        "semantic-release": "22.0.7"
+        "prettier": "3.1.0",
+        "semantic-release": "22.0.8"
       },
       "peerDependencies": {
         "eslint": "^8.34.0"
@@ -49,12 +49,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.4.tgz",
+      "integrity": "sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.4.tgz",
+      "integrity": "sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -254,16 +254,16 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-18.2.0.tgz",
-      "integrity": "sha512-F/DCG791kMFmWg5eIdogakuGeg4OiI2kD430ed1a1Hh3epvrJdeIAgcGADAMIOmF+m0S1+VlIYUKG2dvQQ1Izw==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-18.4.3.tgz",
+      "integrity": "sha512-zop98yfB3A6NveYAZ3P1Mb6bIXuCeWgnUfVNkH4yhIMQpQfzFwseadazOuSn0OOfTt0lWuFauehpm9GcqM5lww==",
       "dev": true,
       "dependencies": {
-        "@commitlint/format": "^18.1.0",
-        "@commitlint/lint": "^18.1.0",
-        "@commitlint/load": "^18.2.0",
-        "@commitlint/read": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/format": "^18.4.3",
+        "@commitlint/lint": "^18.4.3",
+        "@commitlint/load": "^18.4.3",
+        "@commitlint/read": "^18.4.3",
+        "@commitlint/types": "^18.4.3",
         "execa": "^5.0.0",
         "lodash.isfunction": "^3.0.9",
         "resolve-from": "5.0.0",
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-18.1.0.tgz",
-      "integrity": "sha512-8vvvtV3GOLEMHeKc8PjRL1lfP1Y4B6BG0WroFd9PJeRiOc3nFX1J0wlJenLURzl9Qus6YXVGWf+a/ZlbCKT3AA==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-18.4.3.tgz",
+      "integrity": "sha512-729eRRaNta7JZF07qf6SAGSghoDEp9mH7yHU0m7ff0q89W97wDrWCyZ3yoV3mcQJwbhlmVmZPTkPcm7qiAu8WA==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^7.0.2"
@@ -290,12 +290,12 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-18.1.0.tgz",
-      "integrity": "sha512-kbHkIuItXn93o2NmTdwi5Mk1ujyuSIysRE/XHtrcps/27GuUKEIqBJp6TdJ4Sq+ze59RlzYSHMKuDKZbfg9+uQ==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-18.4.3.tgz",
+      "integrity": "sha512-FPZZmTJBARPCyef9ohRC9EANiQEKSWIdatx5OlgeHKu878dWwpyeFauVkhzuBRJFcCA4Uvz/FDtlDKs008IHcA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.4.3",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -303,12 +303,12 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-18.1.0.tgz",
-      "integrity": "sha512-CkPzJ9UBumIo54VDcpmBlaVX81J++wzEhN3DJH9+6PaLeiIG+gkSx8t7C2gfwG7PaiW4HzQtdQlBN5ab+c4vFQ==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-18.4.3.tgz",
+      "integrity": "sha512-MI4fwD9TWDVn4plF5+7JUyLLbkOdzIRBmVeNlk4dcGlkrVA+/l5GLcpN66q9LkFsFv6G2X31y89ApA3hqnqIFg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.4.3",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
@@ -320,21 +320,21 @@
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-18.1.0.tgz",
-      "integrity": "sha512-w3Vt4K+O7+nSr9/gFSEfZ1exKUOPSlJaRpnk7Y+XowEhvwT7AIk1HNANH+gETf0zGZ020+hfiMW/Ome+SNCUsg==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-18.4.3.tgz",
+      "integrity": "sha512-t7FM4c+BdX9WWZCPrrbV5+0SWLgT3kCq7e7/GhHCreYifg3V8qyvO127HF796vyFql75n4TFF+5v1asOOWkV1Q==",
       "dev": true,
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-18.1.0.tgz",
-      "integrity": "sha512-So/w217tGWMZZb1yXcUFNF2qFLyYtSVqbnGoMbX8a+JKcG4oB11Gc1adS0ssUOMivtiNpaLtkSHFynyiwtJtiQ==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-18.4.3.tgz",
+      "integrity": "sha512-8b+ItXYHxAhRAXFfYki5PpbuMMOmXYuzLxib65z2XTqki59YDQJGpJ/wB1kEE5MQDgSTQWtKUrA8n9zS/1uIDQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.4.3",
         "chalk": "^4.1.0"
       },
       "engines": {
@@ -342,12 +342,12 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-18.1.0.tgz",
-      "integrity": "sha512-fa1fY93J/Nx2GH6r6WOLdBOiL7x9Uc1N7wcpmaJ1C5Qs6P+rPSUTkofe2IOhSJIJoboHfAH6W0ru4xtK689t0Q==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-18.4.3.tgz",
+      "integrity": "sha512-ZseOY9UfuAI32h9w342Km4AIaTieeFskm2ZKdrG7r31+c6zGBzuny9KQhwI9puc0J3GkUquEgKJblCl7pMnjwg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/types": "^18.4.3",
         "semver": "7.5.4"
       },
       "engines": {
@@ -355,33 +355,33 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-18.1.0.tgz",
-      "integrity": "sha512-LGB3eI5UYu5LLayibNrRM4bSbowr1z9uyqvp0c7+0KaSJi+xHxy/QEhb6fy4bMAtbXEvygY0sUu9HxSWg41rVQ==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-18.4.3.tgz",
+      "integrity": "sha512-18u3MRgEXNbnYkMOWoncvq6QB8/90m9TbERKgdPqVvS+zQ/MsuRhdvHYCIXGXZxUb0YI4DV2PC4bPneBV/fYuA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^18.1.0",
-        "@commitlint/parse": "^18.1.0",
-        "@commitlint/rules": "^18.1.0",
-        "@commitlint/types": "^18.1.0"
+        "@commitlint/is-ignored": "^18.4.3",
+        "@commitlint/parse": "^18.4.3",
+        "@commitlint/rules": "^18.4.3",
+        "@commitlint/types": "^18.4.3"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.2.0.tgz",
-      "integrity": "sha512-xjX3d3CRlOALwImhOsmLYZh14/+gW/KxsY7+bPKrzmGuFailf9K7ckhB071oYZVJdACnpY4hDYiosFyOC+MpAA==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-18.4.3.tgz",
+      "integrity": "sha512-v6j2WhvRQJrcJaj5D+EyES2WKTxPpxENmNpNG3Ww8MZGik3jWRXtph0QTzia5ZJyPh2ib5aC/6BIDymkUUM58Q==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^18.1.0",
-        "@commitlint/execute-rule": "^18.1.0",
-        "@commitlint/resolve-extends": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/config-validator": "^18.4.3",
+        "@commitlint/execute-rule": "^18.4.3",
+        "@commitlint/resolve-extends": "^18.4.3",
+        "@commitlint/types": "^18.4.3",
         "@types/node": "^18.11.9",
         "chalk": "^4.1.0",
-        "cosmiconfig": "^8.0.0",
+        "cosmiconfig": "^8.3.6",
         "cosmiconfig-typescript-loader": "^5.0.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.merge": "^4.6.2",
@@ -393,22 +393,22 @@
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-18.1.0.tgz",
-      "integrity": "sha512-8dT/jJg73wf3o2Mut/fqEDTpBYSIEVtX5PWyuY/0uviEYeheZAczFo/VMIkeGzhJJn1IrcvAwWsvJ1lVGY2I/w==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-18.4.3.tgz",
+      "integrity": "sha512-ddJ7AztWUIoEMAXoewx45lKEYEOeOlBVWjk8hDMUGpprkuvWULpaXczqdjwVtjrKT3JhhN+gMs8pm5G3vB2how==",
       "dev": true,
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-18.1.0.tgz",
-      "integrity": "sha512-23yv8uBweXWYn8bXk4PjHIsmVA+RkbqPh2h7irupBo2LthVlzMRc4LM6UStasScJ4OlXYYaWOmuP7jcExUF50Q==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-18.4.3.tgz",
+      "integrity": "sha512-eoH7CXM9L+/Me96KVcfJ27EIIbA5P9sqw3DqjJhRYuhaULIsPHFs5S5GBDCqT0vKZQDx0DgxhMpW6AQbnKrFtA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^18.1.0",
-        "conventional-changelog-angular": "^6.0.0",
+        "@commitlint/types": "^18.4.3",
+        "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
       "engines": {
@@ -416,13 +416,13 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-18.1.0.tgz",
-      "integrity": "sha512-rzfzoKUwxmvYO81tI5o1371Nwt3vhcQR36oTNfupPdU1jgSL3nzBIS3B93LcZh3IYKbCIMyMPN5WZ10BXdeoUg==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-18.4.3.tgz",
+      "integrity": "sha512-H4HGxaYA6OBCimZAtghL+B+SWu8ep4X7BwgmedmqWZRHxRLcX2q0bWBtUm5FsMbluxbOfrJwOs/Z0ah4roP/GQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/top-level": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/top-level": "^18.4.3",
+        "@commitlint/types": "^18.4.3",
         "fs-extra": "^11.0.0",
         "git-raw-commits": "^2.0.11",
         "minimist": "^1.2.6"
@@ -432,13 +432,13 @@
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-18.1.0.tgz",
-      "integrity": "sha512-3mZpzOEJkELt7BbaZp6+bofJyxViyObebagFn0A7IHaLARhPkWTivXdjvZHS12nAORftv88Yhbh8eCPKfSvB7g==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-18.4.3.tgz",
+      "integrity": "sha512-30sk04LZWf8+SDgJrbJCjM90gTg2LxsD9cykCFeFu+JFHvBFq5ugzp2eO/DJGylAdVaqxej3c7eTSE64hR/lnw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/config-validator": "^18.4.3",
+        "@commitlint/types": "^18.4.3",
         "import-fresh": "^3.0.0",
         "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0",
@@ -449,15 +449,15 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-18.1.0.tgz",
-      "integrity": "sha512-VJNQ674CRv4znI0DbsjZLVnn647J+BTxHGcrDIsYv7c99gW7TUGeIe5kL80G7l8+5+N0se8v9yn+Prr8xEy6Yw==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-18.4.3.tgz",
+      "integrity": "sha512-8KIeukDf45BiY+Lul1T0imSNXF0sMrlLG6JpLLKolkmYVQ6PxxoNOriwyZ3UTFFpaVbPy0rcITaV7U9JCAfDTA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/ensure": "^18.1.0",
-        "@commitlint/message": "^18.1.0",
-        "@commitlint/to-lines": "^18.1.0",
-        "@commitlint/types": "^18.1.0",
+        "@commitlint/ensure": "^18.4.3",
+        "@commitlint/message": "^18.4.3",
+        "@commitlint/to-lines": "^18.4.3",
+        "@commitlint/types": "^18.4.3",
         "execa": "^5.0.0"
       },
       "engines": {
@@ -465,18 +465,18 @@
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-18.1.0.tgz",
-      "integrity": "sha512-aHIoSDjG0ckxPLYDpODUeSLbEKmF6Jrs1B5JIssbbE9eemBtXtjm9yzdiAx9ZXcwoHlhbTp2fbndDb3YjlvJag==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-18.4.3.tgz",
+      "integrity": "sha512-fy1TAleik4Zfru1RJ8ZU6cOSvgSVhUellxd3WZV1D5RwHZETt1sZdcA4mQN2y3VcIZsUNKkW0Mq8CM9/L9harQ==",
       "dev": true,
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-18.1.0.tgz",
-      "integrity": "sha512-1/USHlolIxJlsfLKecSXH+6PDojIvnzaJGPYwF7MtnTuuXCNQ4izkeqDsRuNMe9nU2VIKpK9OT8Q412kGNmgGw==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-18.4.3.tgz",
+      "integrity": "sha512-E6fJPBLPFL5R8+XUNSYkj4HekIOuGMyJo3mIx2PkYc3clel+pcWQ7TConqXxNWW4x1ugigiIY2RGot55qUq1hw==",
       "dev": true,
       "dependencies": {
         "find-up": "^5.0.0"
@@ -486,9 +486,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-18.1.0.tgz",
-      "integrity": "sha512-65vGxZmbs+2OVwEItxhp3Ul7X2m2LyLfifYI/NdPwRqblmuES2w2aIRhIjb7cwUIBHHSTT8WXj4ixVHQibmvLQ==",
+      "version": "18.4.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-18.4.3.tgz",
+      "integrity": "sha512-cvzx+vtY/I2hVBZHCLrpoh+sA0hfuzHwDc+BAFPimYLjJkpHnghQM+z8W/KyLGkygJh3BtI3xXXq+dKjnSWEmA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -565,9 +565,9 @@
       "peer": true
     },
     "node_modules/@eslint/js": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-      "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
+      "integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.1.tgz",
-      "integrity": "sha512-lyeeeZyESFo+ffI801SaBKmCfsvarO+dgV8/0gD8u1d87clbEdWsP5yC+dSj3zLhb2eIf5SJrn6vDz9AheETHw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.0.2.tgz",
+      "integrity": "sha512-cZUy1gUvd4vttMic7C0lwPed8IYXWYp8kHIMatyhY8t8n3Cpw2ILczkV5pGMPqef7v0bLo0pOHrEHarsau2Ydg==",
       "dev": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
@@ -700,12 +700,12 @@
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.3.tgz",
-      "integrity": "sha512-gm4KmW+pdAfCO5cXJyRZnNfnPE9r6OGpRG8JZpI0eSo1XVk7LXoRcdS7aP4L9azdV0ncHazsLAI0knKjr+snPg==",
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.4.tgz",
+      "integrity": "sha512-MvZx4WvfhBnt7PtH5XE7HORsO7bBk4er1FgRIUr1qJ89NR2I6bWjGyKsxk8z42FPQ34hFQm0Baanh4gzdZR4gQ==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^12.2.0"
+        "@octokit/types": "^12.3.0"
       },
       "engines": {
         "node": ">= 18"
@@ -732,12 +732,12 @@
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.1.2.tgz",
-      "integrity": "sha512-oFba+ioR6HGb0fgqxMta7Kpk/MdffUTuUxNY856l1nXPvh7Qggp8w4AksRx1SDA8SGd+4cbrpkY4k1J/Xz8nZQ==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.1.3.tgz",
+      "integrity": "sha512-pfyqaqpc0EXh5Cn4HX9lWYsZ4gGbjnSmUILeu4u2gnuM50K/wIk9s1Pxt3lVeVwekmITgN/nJdoh43Ka+vye8A==",
       "dev": true,
       "dependencies": {
-        "@octokit/types": "^12.0.0",
+        "@octokit/types": "^12.2.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
@@ -748,15 +748,14 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.5.tgz",
-      "integrity": "sha512-zVKbNbX1xUluD9ZR4/tPs1yuYrK9xeh5fGZUXA6u04XGsTvomg0YO8/ZUC0FqAd49hAOEMFPAVUTh+2lBhOhLA==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.1.6.tgz",
+      "integrity": "sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==",
       "dev": true,
       "dependencies": {
         "@octokit/endpoint": "^9.0.0",
         "@octokit/request-error": "^5.0.0",
         "@octokit/types": "^12.0.0",
-        "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
@@ -778,9 +777,9 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.2.0.tgz",
-      "integrity": "sha512-ZkdHqHJdifVndN7Pha10+qrgAjy3AcG//Vmjr/o5UFuTiYCcMhqDj39Yr9VM9zJ/42KO2xAYhV7cvLnLI9Kvwg==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.3.0.tgz",
+      "integrity": "sha512-nJ8X2HRr234q3w/FcovDlA+ttUU4m1eJAourvfUUtwAWeqL8AsyRqfnLvVnYn3NFbUnsmzQCzLNdFerPwdmcDQ==",
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^19.0.2"
@@ -828,9 +827,9 @@
       }
     },
     "node_modules/@rushstack/eslint-patch": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.1.tgz",
-      "integrity": "sha512-6i/8UoL0P5y4leBIGzvkZdS85RDMG9y1ihZzmTZQ5LdHUYmZ7pKFoj8X0236s3lusPs1Fa5HTQUpwI+UfTcmeA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.6.0.tgz",
+      "integrity": "sha512-2/U3GXA6YiPYQDLGwtGlnNgKYBSwCFIHf8Y9LUY5VATHdtbLlU0Y1R3QoBnT0aB4qv/BEiVVsj7LJXoQCgJ2vA=="
     },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.3",
@@ -871,18 +870,6 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/commit-analyzer/node_modules/conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@semantic-release/error": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
@@ -915,9 +902,9 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.2.tgz",
-      "integrity": "sha512-S9tTms9MSrFnW97inhNhEqQiTNmls1zgE3bCxLbWhom0vClRe43B9N9D5NVepTwbr7wXehXJG+ok8B8neG1bsA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.3.tgz",
+      "integrity": "sha512-FAjXb1F84CVI6IG8fWi+XS9ErYD+s3MHkP03zBa3+GyUrV4kqwYu/WPppIciHxujGFR51SAWPkOY5rnH6ZlrxA==",
       "dev": true,
       "dependencies": {
         "@octokit/core": "^5.0.0",
@@ -928,7 +915,7 @@
         "aggregate-error": "^5.0.0",
         "debug": "^4.3.4",
         "dir-glob": "^3.0.1",
-        "globby": "^13.1.4",
+        "globby": "^14.0.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
         "issue-parser": "^6.0.0",
@@ -997,19 +984,20 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.0.tgz",
+      "integrity": "sha512-/1WM/LNHRAOH9lZta77uGbq0dAEQM+XjNesWwhlERDVenqothRbnzTrL3/LrIoEPPjeUHC3vrS6TwoyxeHs7MQ==",
       "dev": true,
       "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
+        "@sindresorhus/merge-streams": "^1.0.0",
+        "fast-glob": "^3.3.2",
         "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1027,13 +1015,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+    "node_modules/@semantic-release/github/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1288,18 +1288,6 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
@@ -1313,15 +1301,27 @@
       }
     },
     "node_modules/@sindresorhus/is": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-      "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-1.0.0.tgz",
+      "integrity": "sha512-rUV5WyJrJLoloD4NDN1V1+LDMDWOa4OTsT4yYJwQNpTU6FWxkxHpL7eu4w+DmiH8x/EAM1otkPE1+LaspIbplw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@types/json-schema": {
@@ -1341,9 +1341,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.18.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
-      "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
+      "version": "18.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.12.tgz",
+      "integrity": "sha512-G7slVfkwOm7g8VqcEF1/5SXiMjP3Tbt+pXDU3r/qhlM2KkGm786DUD4xyMA2QzEElFrv/KZV9gjygv4LnkpbMQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1356,20 +1356,20 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.5.tgz",
-      "integrity": "sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg=="
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.10.0.tgz",
-      "integrity": "sha512-uoLj4g2OTL8rfUQVx2AFO1hp/zja1wABJq77P6IclQs6I/m9GLrm7jCdgzZkvWdDCQf1uEvoa8s8CupsgWQgVg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.12.0.tgz",
+      "integrity": "sha512-XOpZ3IyJUIV1b15M7HVOpgQxPPF7lGXgsfcEIu3yDxFPaf/xZKt7s9QO/pbk7vpWQyVulpJbu4E5LwpZiQo4kA==",
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.10.0",
-        "@typescript-eslint/type-utils": "6.10.0",
-        "@typescript-eslint/utils": "6.10.0",
-        "@typescript-eslint/visitor-keys": "6.10.0",
+        "@typescript-eslint/scope-manager": "6.12.0",
+        "@typescript-eslint/type-utils": "6.12.0",
+        "@typescript-eslint/utils": "6.12.0",
+        "@typescript-eslint/visitor-keys": "6.12.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1528,14 +1528,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.10.0.tgz",
-      "integrity": "sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.12.0.tgz",
+      "integrity": "sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.10.0",
-        "@typescript-eslint/types": "6.10.0",
-        "@typescript-eslint/typescript-estree": "6.10.0",
-        "@typescript-eslint/visitor-keys": "6.10.0",
+        "@typescript-eslint/scope-manager": "6.12.0",
+        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/typescript-estree": "6.12.0",
+        "@typescript-eslint/visitor-keys": "6.12.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1555,12 +1555,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
-      "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.12.0.tgz",
+      "integrity": "sha512-5gUvjg+XdSj8pcetdL9eXJzQNTl3RD7LgUiYTl8Aabdi8hFkaGSYnaS6BLc0BGNaDH+tVzVwmKtWvu0jLgWVbw==",
       "dependencies": {
-        "@typescript-eslint/types": "6.10.0",
-        "@typescript-eslint/visitor-keys": "6.10.0"
+        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/visitor-keys": "6.12.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1571,12 +1571,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.10.0.tgz",
-      "integrity": "sha512-wYpPs3hgTFblMYwbYWPT3eZtaDOjbLyIYuqpwuLBBqhLiuvJ+9sEp2gNRJEtR5N/c9G1uTtQQL5AhV0fEPJYcg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.12.0.tgz",
+      "integrity": "sha512-WWmRXxhm1X8Wlquj+MhsAG4dU/Blvf1xDgGaYCzfvStP2NwPQh6KBvCDbiOEvaE0filhranjIlK/2fSTVwtBng==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.10.0",
-        "@typescript-eslint/utils": "6.10.0",
+        "@typescript-eslint/typescript-estree": "6.12.0",
+        "@typescript-eslint/utils": "6.12.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1597,9 +1597,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
-      "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.12.0.tgz",
+      "integrity": "sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -1609,12 +1609,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
-      "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.12.0.tgz",
+      "integrity": "sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==",
       "dependencies": {
-        "@typescript-eslint/types": "6.10.0",
-        "@typescript-eslint/visitor-keys": "6.10.0",
+        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/visitor-keys": "6.12.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1635,16 +1635,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.10.0.tgz",
-      "integrity": "sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.12.0.tgz",
+      "integrity": "sha512-LywPm8h3tGEbgfyjYnu3dauZ0U7R60m+miXgKcZS8c7QALO9uWJdvNoP+duKTk2XMWc7/Q3d/QiCuLN9X6SWyQ==",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.10.0",
-        "@typescript-eslint/types": "6.10.0",
-        "@typescript-eslint/typescript-estree": "6.10.0",
+        "@typescript-eslint/scope-manager": "6.12.0",
+        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/typescript-estree": "6.12.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1659,11 +1659,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
-      "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.12.0.tgz",
+      "integrity": "sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==",
       "dependencies": {
-        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/types": "6.12.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -2208,15 +2208,15 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
-      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
@@ -2880,15 +2880,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-      "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+      "version": "8.54.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
+      "integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.3",
-        "@eslint/js": "8.53.0",
+        "@eslint/js": "8.54.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -3087,11 +3087,11 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.2.0.tgz",
-      "integrity": "sha512-/nG2Uurd6AY7CI6zlgjHPOoiPY8B7EYMUWdNb5w+EzyauYiQjjD5lQwAI1FlkBbCCFFZw/CdZIPQhXumYoiyaw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.4.0.tgz",
+      "integrity": "sha512-til+vyf56wAUgFv5guBA1Zo5lTw9xj2kCeK/g+9NBtsRy1rkGrlqnvxYNuFExcK3VsPhUUtx5UdScEDz9ahQ5Q==",
       "dependencies": {
-        "@typescript-eslint/utils": "^6.7.5",
+        "@typescript-eslint/utils": "^6.10.0",
         "minimatch": "^9.0.3",
         "natural-compare-lite": "^1.4.0"
       },
@@ -3523,9 +3523,9 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-      "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
@@ -3533,7 +3533,7 @@
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -4252,9 +4252,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "engines": {
         "node": ">= 4"
       }
@@ -4283,11 +4283,12 @@
       }
     },
     "node_modules/import-from-esm": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.2.1.tgz",
-      "integrity": "sha512-Nly5Ab75rWZmOwtMa0B0NQNnHGcHOQ2zkU/bVENwK2lbPq+kamPDqNKNJ0hF7w7lR/ETD5nGgJq0XbofsZpYCA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.3.tgz",
+      "integrity": "sha512-U3Qt/CyfFpTUv6LOP2jRTLYjphH6zg3okMfHbyqRa/W2w6hr8OsJWVggNlR4jxuojQy81TgTJTxgSkyoteRGMQ==",
       "dev": true,
       "dependencies": {
+        "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
       },
       "engines": {
@@ -5134,9 +5135,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.3.tgz",
+      "integrity": "sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -5155,9 +5156,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.5.tgz",
-      "integrity": "sha512-14QG3shv8Kg/xc0Yh6TNkMj90wXH9mmldi5941I2OevfJ/FQAFLEwtwU2/FfgSAOMlWHrEukWSGQf8MiVYNG2A==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -5167,9 +5168,9 @@
       }
     },
     "node_modules/marked-terminal": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-6.0.0.tgz",
-      "integrity": "sha512-6rruICvqRfA4N+Mvdc0UyDbLA0A0nI5omtARIlin3P2F+aNc3EbW91Rd9HTuD0v9qWyHmNIu8Bt40gAnPfldsg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-6.1.0.tgz",
+      "integrity": "sha512-QaCSF6NV82oo6K0szEnmc65ooDeW0T/Adcyf0fcW+Hto2GT1VADFg8dn1zaeHqzj65fqDH1hMNChGNRaC/lbkA==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^6.2.0",
@@ -5183,7 +5184,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "marked": ">=1 <10"
+        "marked": ">=1 <11"
       }
     },
     "node_modules/marked-terminal/node_modules/chalk": {
@@ -5327,15 +5328,18 @@
       "dev": true
     },
     "node_modules/node-emoji": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.0.tgz",
-      "integrity": "sha512-tcsBm9C6FmPN5Wo7OjFi9lgMyJjvkAeirmjR/ax8Ttfqy4N8PoFic26uqFTIgayHPNI5FH4ltUvfh9kHzwcK9A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+      "integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
       "dev": true,
       "dependencies": {
-        "@sindresorhus/is": "^3.1.2",
+        "@sindresorhus/is": "^4.6.0",
         "char-regex": "^1.0.2",
         "emojilib": "^2.4.0",
         "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/normalize-package-data": {
@@ -5366,9 +5370,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.3.tgz",
-      "integrity": "sha512-GbUui/rHTl0mW8HhJSn4A0Xg89yCR3I9otgJT1i0z1QBPOVlgbh6rlcUTpHT8Gut9O1SJjWRUU0nEcAymhG2tQ==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.4.tgz",
+      "integrity": "sha512-umEuYneVEYO9KoEEI8n2sSGmNQeqco/3BSeacRlqIkCzw4E7XGtYSWMeJobxzr6hZ2n9cM+u5TsMTcC5bAgoWA==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -5446,18 +5450,18 @@
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^7.2.1",
-        "@npmcli/config": "^8.0.1",
+        "@npmcli/config": "^8.0.2",
         "@npmcli/fs": "^3.1.0",
         "@npmcli/map-workspaces": "^3.0.4",
         "@npmcli/package-json": "^5.0.0",
         "@npmcli/promise-spawn": "^7.0.0",
         "@npmcli/run-script": "^7.0.2",
-        "@sigstore/tuf": "^2.1.0",
+        "@sigstore/tuf": "^2.2.0",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
         "cacache": "^18.0.0",
         "chalk": "^5.3.0",
-        "ci-info": "^3.9.0",
+        "ci-info": "^4.0.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
         "columnify": "^1.6.0",
@@ -5468,16 +5472,16 @@
         "hosted-git-info": "^7.0.1",
         "ini": "^4.1.1",
         "init-package-json": "^6.0.0",
-        "is-cidr": "^4.0.2",
+        "is-cidr": "^5.0.3",
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^8.0.1",
         "libnpmdiff": "^6.0.3",
-        "libnpmexec": "^7.0.3",
+        "libnpmexec": "^7.0.4",
         "libnpmfund": "^5.0.1",
         "libnpmhook": "^10.0.0",
         "libnpmorg": "^6.0.1",
         "libnpmpack": "^6.0.3",
-        "libnpmpublish": "^9.0.1",
+        "libnpmpublish": "^9.0.2",
         "libnpmsearch": "^7.0.0",
         "libnpmteam": "^6.0.0",
         "libnpmversion": "^5.0.1",
@@ -5506,7 +5510,7 @@
         "semver": "^7.5.4",
         "spdx-expression-parse": "^3.0.1",
         "ssri": "^10.0.5",
-        "strip-ansi": "^6.0.1",
+        "strip-ansi": "^7.1.0",
         "supports-color": "^9.4.0",
         "tar": "^6.2.0",
         "text-table": "~0.2.0",
@@ -5563,18 +5567,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "dev": true,
@@ -5598,21 +5590,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
       "dev": true,
@@ -5633,58 +5610,6 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/agent-base": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
@@ -5735,13 +5660,13 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "8.0.1",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.2",
-        "ci-info": "^3.8.0",
+        "ci-info": "^4.0.0",
         "ini": "^4.1.0",
         "nopt": "^7.0.0",
         "proc-log": "^3.0.0",
@@ -5763,6 +5688,21 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
@@ -5950,7 +5890,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -5964,7 +5904,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -6019,6 +5959,18 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/npm/node_modules/agent-base": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
       "dev": true,
@@ -6033,24 +5985,24 @@
       }
     },
     "node_modules/npm/node_modules/ansi-regex": {
-      "version": "5.0.1",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/ansi-styles": {
-      "version": "4.3.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -6218,7 +6170,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "3.9.0",
+      "version": "4.0.0",
       "dev": true,
       "funding": [
         {
@@ -6233,15 +6185,15 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "3.1.1",
+      "version": "4.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "ip-regex": "^4.1.0"
+        "ip-regex": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/clean-stack": {
@@ -6264,6 +6216,27 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/cli-table3": {
@@ -6337,6 +6310,27 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/columnify/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/columnify/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
@@ -6541,10 +6535,13 @@
       }
     },
     "node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/npm/node_modules/gauge": {
       "version": "5.0.1",
@@ -6563,6 +6560,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/glob": {
@@ -6593,23 +6611,23 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/has": {
-      "version": "1.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
+    },
+    "node_modules/npm/node_modules/hasown": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "7.0.1",
@@ -6628,6 +6646,32 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/http-proxy-agent": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/npm/node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -6726,33 +6770,36 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/ip-regex": {
-      "version": "4.3.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "4.0.2",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^3.1.1"
+        "cidr-regex": "4.0.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.13.0",
+      "version": "2.13.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6870,14 +6917,14 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "7.0.3",
+      "version": "7.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/arborist": "^7.2.1",
         "@npmcli/run-script": "^7.0.2",
-        "ci-info": "^3.7.1",
+        "ci-info": "^4.0.0",
         "npm-package-arg": "^11.0.1",
         "npmlog": "^7.0.1",
         "pacote": "^17.0.4",
@@ -6945,12 +6992,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "9.0.1",
+      "version": "9.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "ci-info": "^3.6.1",
+        "ci-info": "^4.0.0",
         "normalize-package-data": "^6.0.0",
         "npm-package-arg": "^11.0.1",
         "npm-registry-fetch": "^16.0.0",
@@ -7005,10 +7052,13 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.0.1",
+      "version": "10.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -7778,7 +7828,7 @@
       }
     },
     "node_modules/npm/node_modules/signal-exit": {
-      "version": "4.0.2",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7826,6 +7876,20 @@
       "engines": {
         "node": ">= 10.13.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/socks-proxy-agent": {
+      "version": "8.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
@@ -7910,7 +7974,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/strip-ansi": {
+    "node_modules/npm/node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "dev": true,
       "inBundle": true,
@@ -7922,6 +7995,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
@@ -7931,6 +8040,15 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -8167,28 +8285,40 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
@@ -8212,21 +8342,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
@@ -8725,9 +8840,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -8827,15 +8942,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/read-pkg": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.0.tgz",
-      "integrity": "sha512-SBoBio4xhJmlF4xs9IBliWZGSbDAnrOfQkLGL7xB+RYEUZNAN2LlNkzO45B7gc7c2dLMX987bhHAaJ/LG3efeQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
       "dev": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.3",
         "normalize-package-data": "^6.0.0",
         "parse-json": "^8.0.0",
-        "type-fest": "^4.6.0"
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -8863,9 +8979,9 @@
       }
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
-      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.2.tgz",
+      "integrity": "sha512-mcvrCjixA5166hSrUoJgGb9gBQN4loMYyj9zxuMs/66ibHNEFd5JXMw37YVDx58L4/QID9jIzdTBB4mDwDJ6KQ==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -8902,9 +9018,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
-      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.2.tgz",
+      "integrity": "sha512-mcvrCjixA5166hSrUoJgGb9gBQN4loMYyj9zxuMs/66ibHNEFd5JXMw37YVDx58L4/QID9jIzdTBB4mDwDJ6KQ==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -9154,9 +9270,9 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "22.0.7",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.7.tgz",
-      "integrity": "sha512-Stx23Hjn7iU8GOAlhG3pHlR7AoNEahj9q7lKBP0rdK2BasGtJ4AWYh3zm1u3SCMuFiA8y4CE/Gu4RGKau1WiaQ==",
+      "version": "22.0.8",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.8.tgz",
+      "integrity": "sha512-55rb31jygqIYsGU/rY+gXXm2fnxBIWo9azOjxbqKsPnq7p70zwZ5v+xnD7TxJC+zvS3sy1eHLGXYWCaX3WI76A==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
@@ -9175,6 +9291,7 @@
         "git-log-parser": "^1.2.0",
         "hook-std": "^3.0.0",
         "hosted-git-info": "^7.0.0",
+        "import-from-esm": "^1.3.1",
         "lodash-es": "^4.17.21",
         "marked": "^9.0.0",
         "marked-terminal": "^6.0.0",
@@ -10142,9 +10259,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10194,6 +10311,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unique-string": {

--- a/package.json
+++ b/package.json
@@ -27,16 +27,16 @@
     "repair": "npx --no rimraf .git/hooks node_modules package-lock.json && npm install"
   },
   "peerDependencies": {
-    "eslint": "^8.34.0"
+    "eslint": "^8.54.0"
   },
   "dependencies": {
-    "@rushstack/eslint-patch": "^1.5.1",
-    "@typescript-eslint/eslint-plugin": "^6.10.0",
-    "@typescript-eslint/parser": "^6.10.0",
+    "@rushstack/eslint-patch": "^1.6.0",
+    "@typescript-eslint/eslint-plugin": "^6.12.0",
+    "@typescript-eslint/parser": "^6.12.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",
-    "eslint-plugin-perfectionist": "^2.2.0",
+    "eslint-plugin-perfectionist": "^2.4.0",
     "eslint-plugin-playwright": "^0.18.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
@@ -46,14 +46,14 @@
   },
   "devDependencies": {
     "@boehringer-ingelheim/prettier-config": "1.0.0",
-    "@commitlint/cli": "18.2.0",
-    "@commitlint/config-conventional": "18.1.0",
-    "@commitlint/types": "18.1.0",
+    "@commitlint/cli": "18.4.3",
+    "@commitlint/config-conventional": "18.4.3",
+    "@commitlint/types": "18.4.3",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/git": "10.0.1",
     "dotenv-cli": "7.3.0",
     "husky": "8.0.3",
-    "prettier": "3.0.3",
-    "semantic-release": "22.0.7"
+    "prettier": "3.1.0",
+    "semantic-release": "22.0.8"
   }
 }


### PR DESCRIPTION
- bump @commitlint/cli 18.2.0 to 18.4.3
- bump @commitlint/config-conventional 18.1.0 to 18.4.3
- bump @commitlint/types 18.1.0 to 18.4.3
- bump @rushstack/eslint-patch ^1.5.1 to ^1.6.0
- bump @typescript-eslint/eslint-plugin ^6.10.0 to ^6.12.0
- bump @typescript-eslint/parser ^6.10.0 to ^6.12.0
- bump eslint from ^8.34.0 to ^8.54.0
- bump eslint-plugin-perfectionist ^2.2.0 to ^2.4.0
- bump prettier 3.0.3 to 3.1.0
- bump semantic-release 22.0.7 to 22.0.8