### PR TITLE
feat(deps): update eslint-plugin-perfectionist@3

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -1,10 +1,15 @@
-const { SORT_CLASSES_GROUPS, SORT_IMPORTS_GROUPS } = require('../lib/eslint-plugin-perfectionist');
+const {
+  SORT_CLASSES_GROUPS,
+  SORT_IMPORTS_GROUPS,
+  SORT_INTERSECTION_TYPES_GROUPS,
+} = require('../lib/eslint-plugin-perfectionist');
 
 /**
  * Workaround to allow ESLint to resolve plugins that were installed
  * by an external config, see https://github.com/eslint/eslint/issues/3458.
  */
 require('@rushstack/eslint-patch/modern-module-resolution');
+const eslintPluginPerfectionist = require('eslint-plugin-perfectionist');
 
 /** @type {import('eslint').ESLint.ConfigData & { parserOptions: import('eslint').ESLint.ConfigData['parserOptions'] & import('@typescript-eslint/parser').ParserOptions } }  */
 module.exports = {
@@ -17,7 +22,7 @@ module.exports = {
     'plugin:@typescript-eslint/stylistic-type-checked',
     'plugin:import/recommended',
     'plugin:import/typescript',
-    'plugin:perfectionist/recommended-natural',
+    'plugin:perfectionist/recommended-natural-legacy',
     'plugin:sonarjs/recommended-legacy',
   ],
   overrides: [
@@ -104,31 +109,44 @@ module.exports = {
     'import/no-named-as-default-member': 'off',
 
     // eslint-plugin-perfectionist: https://github.com/azat-io/eslint-plugin-perfectionist
-    'perfectionist/sort-array-includes': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-astro-attributes': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-classes': ['error', { groups: SORT_CLASSES_GROUPS, 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-enums': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-exports': ['error', { 'ignore-case': true, type: 'natural' }],
+    'perfectionist/sort-classes': [
+      'error',
+      {
+        ...eslintPluginPerfectionist.configs['recommended-natural-legacy'].rules['perfectionist/sort-classes'][1],
+        groups: SORT_CLASSES_GROUPS,
+      },
+    ],
     'perfectionist/sort-imports': [
       'error',
       {
+        ...eslintPluginPerfectionist.configs['recommended-natural-legacy'].rules['perfectionist/sort-imports'][1],
         groups: SORT_IMPORTS_GROUPS,
-        'ignore-case': true,
-        'newlines-between': 'ignore',
-        type: 'natural',
+        newlinesBetween: 'ignore',
       },
     ],
-    'perfectionist/sort-interfaces': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-intersection-types': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-jsx-props': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-maps': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-named-exports': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-named-imports': ['error', { 'ignore-alias': true, 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-object-types': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-objects': ['error', { 'ignore-case': true, 'partition-by-comment': true, type: 'natural' }],
-    'perfectionist/sort-svelte-attributes': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-union-types': ['error', { 'ignore-case': true, type: 'natural' }],
-    'perfectionist/sort-vue-attributes': ['error', { 'ignore-case': true, type: 'natural' }],
+    'perfectionist/sort-intersection-types': [
+      'error',
+      {
+        ...eslintPluginPerfectionist.configs['recommended-natural-legacy'].rules[
+          'perfectionist/sort-intersection-types'
+        ][1],
+        groups: SORT_INTERSECTION_TYPES_GROUPS,
+      },
+    ],
+    'perfectionist/sort-named-imports': [
+      'error',
+      {
+        ...eslintPluginPerfectionist.configs['recommended-natural-legacy'].rules['perfectionist/sort-named-imports'][1],
+        ignoreAlias: true,
+      },
+    ],
+    'perfectionist/sort-objects': [
+      'error',
+      {
+        ...eslintPluginPerfectionist.configs['recommended-natural-legacy'].rules['perfectionist/sort-objects'][1],
+        partitionByComment: true,
+      },
+    ],
   },
   settings: {
     'import/resolver': {

--- a/lib/eslint-plugin-perfectionist.js
+++ b/lib/eslint-plugin-perfectionist.js
@@ -35,7 +35,28 @@ const SORT_CLASSES_GROUPS = [
   'unknown',
 ];
 
+/**
+ * This array can be used to configure the perfectionist/sort-intersection-types rule.
+ * The following group names are available for configuration: https://perfectionist.dev/rules/sort-intersection-types#groups
+ */
+const SORT_INTERSECTION_TYPES_GROUPS = [
+  'conditional',
+  'function',
+  'import',
+  'interseciont',
+  'union',
+  'named',
+  'keyword',
+  'literal',
+  'operator',
+  'tuple',
+  'object',
+  'nullish',
+  'unknown',
+];
+
 module.exports = {
   SORT_CLASSES_GROUPS,
   SORT_IMPORTS_GROUPS,
+  SORT_INTERSECTION_TYPES_GROUPS,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@boehringer-ingelheim/eslint-config",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@boehringer-ingelheim/eslint-config",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "MIT",
       "dependencies": {
         "@rushstack/eslint-patch": "^1.10.3",
@@ -15,7 +15,7 @@
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsx-a11y": "^6.9.0",
-        "eslint-plugin-perfectionist": "^2.11.0",
+        "eslint-plugin-perfectionist": "^3.0.0",
         "eslint-plugin-playwright": "^1.6.2",
         "eslint-plugin-react": "^7.35.0",
         "eslint-plugin-react-hooks": "^4.6.2",
@@ -3516,20 +3516,24 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-2.11.0.tgz",
-      "integrity": "sha512-XrtBtiu5rbQv88gl+1e2RQud9te9luYNvKIgM9emttQ2zutHPzY/AQUucwxscDKV4qlTkvLTxjOFvxqeDpPorw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-3.0.0.tgz",
+      "integrity": "sha512-B+leJTo1YjxiNIm8Yv0rCHp4eWh9RaJHO6T1ifxd26wg8NCbEiWSdqZVeYLWPCI+zS1dlf89WpOkUzG7cE4vtQ==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^6.13.0 || ^7.0.0",
-        "minimatch": "^9.0.3",
+        "@typescript-eslint/types": "^7.16.1",
+        "@typescript-eslint/utils": "^7.16.1",
+        "minimatch": "^10.0.1",
         "natural-compare-lite": "^1.4.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
         "astro-eslint-parser": "^1.0.2",
         "eslint": ">=8.0.0",
         "svelte": ">=3.0.0",
-        "svelte-eslint-parser": "^0.37.0",
+        "svelte-eslint-parser": "^0.40.0",
         "vue-eslint-parser": ">=9.0.0"
       },
       "peerDependenciesMeta": {
@@ -3545,6 +3549,21 @@
         "vue-eslint-parser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-playwright": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.9.0",
-    "eslint-plugin-perfectionist": "^2.11.0",
+    "eslint-plugin-perfectionist": "^3.0.0",
     "eslint-plugin-playwright": "^1.6.2",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^4.6.2",


### PR DESCRIPTION
- perform required migration steps, see: https://github.com/azat-io/eslint-plugin-perfectionist/releases/tag/v3.0.0
- remove customized rules that covers natural sorting and ignore case sensitive as it is covered by the new configuration
- add initial group to sort intersection-types

BREAKING CHANGE: update to eslint-plugin-perfectionist@3