### PR TITLE
feat(base): add rule @typescript-eslint/naming-convention

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -43,6 +43,68 @@ module.exports = {
   rules: {
     // @typescript-eslint: https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/eslint-plugin/docs/rules
     '@typescript-eslint/adjacent-overload-signatures': 'off', // disabled due to conflict with eslint-plugin-perfectionist
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        // Enforce that interface names do not start with an 'I'
+        custom: {
+          match: false,
+          regex: '^I[A-Z]',
+        },
+        format: ['StrictPascalCase'],
+        leadingUnderscore: 'forbid',
+        selector: 'interface',
+        trailingUnderscore: 'forbid',
+      },
+      {
+        // Enforce that type alias names do not start with an 'T'
+        custom: {
+          match: false,
+          regex: '^T[A-Z]',
+        },
+        format: ['StrictPascalCase'],
+        leadingUnderscore: 'forbid',
+        selector: 'typeAlias',
+        trailingUnderscore: 'forbid',
+      },
+      {
+        // Enforce that all top-level variables are in UPPER_CASE
+        format: ['UPPER_CASE'],
+        leadingUnderscore: 'forbid',
+        modifiers: ['global'],
+        selector: 'variable',
+        trailingUnderscore: 'forbid',
+        types: ['boolean', 'number', 'string'],
+      },
+      {
+        // Enforce that all top-level array variables are in UPPER_CASE and are suffixed with a 'S' to indicate plural form
+        format: ['UPPER_CASE'],
+        leadingUnderscore: 'forbid',
+        modifiers: ['global'],
+        selector: 'variable',
+        suffix: ['S'],
+        trailingUnderscore: 'forbid',
+        types: ['array'],
+      },
+      {
+        // Enforce that array variables are suffixed with a 's' to indicate plural form
+        format: ['strictCamelCase'],
+        leadingUnderscore: 'forbid',
+        selector: 'variable',
+        suffix: ['s'],
+        trailingUnderscore: 'forbid',
+        types: ['array'],
+      },
+      {
+        // Enforce that boolean variables are prefixed with an allowed verb
+        format: ['StrictPascalCase'],
+        leadingUnderscore: 'forbid',
+        prefix: ['is', 'has', 'should', 'can'],
+        selector: 'variable',
+        trailingUnderscore: 'forbid',
+        types: ['boolean'],
+      },
+    ],
     '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: true }],
     '@typescript-eslint/no-misused-promises': [
       'error',


### PR DESCRIPTION
- basic configuration to enforce naming convention for a ' interface', 'typeAlias' and 'variable'