### PR TITLE
Switching from eslint dot-notation to @typescript-eslint/dot-notation

### DIFF
--- a/base/index.js
+++ b/base/index.js
@@ -67,11 +67,11 @@ module.exports = {
     '@typescript-eslint/sort-type-constituents': 'off', // disabled due to conflict with eslint-plugin-perfectionist
 
     // eslint: https://github.com/eslint/eslint/tree/main/lib/rules
+    '@typescript-eslint/dot-notation': ['error', { allowPattern: '^[a-z]+(_[a-z]+)+$' }],
     'arrow-body-style': ['error', 'as-needed'],
     camelcase: 'warn',
     curly: 'error',
     'default-case': 'error',
-    'dot-notation': ['error', { allowPattern: '^[a-z]+(_[a-z]+)+$' }],
     eqeqeq: 'error',
     'logical-assignment-operators': ['error', 'never'],
     'no-console': ['warn', { allow: ['warn', 'error'] }],


### PR DESCRIPTION
The dot-notation of eslint conflicts with the noPropertyAccessFromIndexSignature property of the TS configuration. typescript-eslint fixes this already. Therefor switching to this rule. (See https://typescript-eslint.io/rules/dot-notation/).