### PR TITLE
Adds a prettier-disable shared config

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ This shared ESLint configuration is designed to enforce best practices and recom
 - [`playwright/prefer-to-have-length`](https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/prefer-to-have-length.md): enforces the use of `.toHaveLength()` instead of `.toEqual(n)` when testing the length of an object.
 - [`playwright/require-top-level-describe`](https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/require-top-level-describe.md): requires tests to be organized into top-level `describe()` blocks.
 
+### `@boehringer-ingelheim/eslint-config/prettier-disable`
+
+```js
+module.exports = {
+  extends: [
+    '@boehringer-ingelheim/eslint-config/base/strict',
+    // Following needs eslint-plugin-prettier to be installed as described by https://github.com/prettier/eslint-plugin-prettier
+    // Should be second to last
+    'plugin:prettier/recommended',
+    // Should be last
+    '@boehringer-ingelheim/eslint-config/prettier-disable'
+  ],
+};
+```
+
+This shared ESLint configuration is wrapper around [`eslint-config-disable`](https://github.com/prettier/eslint-config-prettier), which is used to turn off all rules that are unnecessary or might conflict with Prettier. This wrapper reenables a few rules that can be used with our shared configurations as we are using specific options of those rules which are compatible with Prettier (see [Special Rules](https://github.com/prettier/eslint-config-prettier#special-rules)). Following rules are reenabled:
+
+- [`curly`](https://github.com/eslint/eslint/blob/main/docs/src/rules/curly.md) with the (default) option "all": Enforce consistent brace style for all control statements
+- [`no-confusing-arrow`](https://github.com/eslint/eslint/blob/main/docs/src/rules/no-confusing-arrow.md) with allowParens `false` and onlyOneSimpleParam `true`: Disallow arrow functions where they could be confused with comparisons.
+
 ## Local Development
 
 ### Install Dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^7.17.0",
         "@typescript-eslint/parser": "^7.17.0",
+        "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-deprecation": "^3.0.0",
         "eslint-plugin-import": "^2.29.1",
@@ -3308,6 +3309,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@rushstack/eslint-patch": "^1.10.3",
     "@typescript-eslint/eslint-plugin": "^7.17.0",
     "@typescript-eslint/parser": "^7.17.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-deprecation": "^3.0.0",
     "eslint-plugin-import": "^2.29.1",

--- a/prettier-disable/index.js
+++ b/prettier-disable/index.js
@@ -1,0 +1,14 @@
+/**
+ * Workaround to allow ESLint to resolve plugins that were installed
+ * by an external config, see https://github.com/eslint/eslint/issues/3458.
+ */
+require('@rushstack/eslint-patch/modern-module-resolution');
+
+/** @type {import('eslint').ESLint.ConfigData & { parserOptions: import('eslint').ESLint.ConfigData['parserOptions'] & import('@typescript-eslint/parser').ParserOptions } }  */
+module.exports = {
+  extends: ['prettier'],
+  rules: {
+    curly: 'error',
+    'no-confusing-arrow': ['error', { allowParens: false, onlyOneSimpleParam: false }],
+  },
+};


### PR DESCRIPTION
This PR adds another shared config, which wraps [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) (which disables rules that are not necessary or not compatible with prettier). It reenables some rules which are compatible with our specific config.