### PR TITLE
Fix prettier disable config

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "base",
     "lib",
     "react",
-    "playwright"
+    "playwright",
+    "prettier-disable"
   ],
   "main": "base/index.js",
   "scripts": {


### PR DESCRIPTION
Adds the prettier-disable folder to the files array in package.json to be published.