### PR TITLE
feat(base): [typescript-eslint] update parserOptions to use projectService instead of project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# [7.0.0-typescript-eslint-parser-options.1](https://github.com/Boehringer-Ingelheim/eslint-config/compare/v6.0.1...v7.0.0-typescript-eslint-parser-options.1) (2025-01-07)
+
+
+### Bug Fixes
+
+* **base:** switch some perfectionist references to flatconfig ([a6697cc](https://github.com/Boehringer-Ingelheim/eslint-config/commit/a6697cc2c6c11ff717732abe741d1300c6d3a608))
+
+
+### Features
+
+* add basic typing to the index.js ([ce3fbb0](https://github.com/Boehringer-Ingelheim/eslint-config/commit/ce3fbb063150a162085df2f6e110460670612bb1))
+* **base:** [typescript-eslint] update parserOptions to use projectService instead of project ([02ac930](https://github.com/Boehringer-Ingelheim/eslint-config/commit/02ac930eca6f1d9da4f2c724c1febebd9f3c2524))
+* migrates to flat-config ([b22a872](https://github.com/Boehringer-Ingelheim/eslint-config/commit/b22a872a1589516d571c8907e6ec30bb2b529f94))
+
+
+### BREAKING CHANGES
+
+* migrate to flat config
+* drop support for legacy config
+
 # [7.0.0-next.2](https://github.com/Boehringer-Ingelheim/eslint-config/compare/v7.0.0-next.1...v7.0.0-next.2) (2024-12-20)
 
 

--- a/README.md
+++ b/README.md
@@ -85,21 +85,20 @@ The following plugins are used in this configuration:
 
 Additionally, the [`eslint-plugin-perfectionist`](https://github.com/azat-io/eslint-plugin-perfectionist) is used to automatically fix sorting issues.
 
-This configuration also sets up the TypeScript parser [`@typescript-eslint/parser`](https://typescript-eslint.io/architecture/parser) and [`eslint-import-resolver-typescript`](https://github.com/import-js/eslint-import-resolver-typescript). The TypeScript project file `./tsconfig.json` is set as default value for the project option in the parser configuration. If this is not the case, this must be changed accordingly:
+This configuration also sets up the TypeScript parser [`@typescript-eslint/parser`](https://typescript-eslint.io/packages/parser/) and [`eslint-import-resolver-typescript`](https://github.com/import-js/eslint-import-resolver-typescript). The TypeScript project configuration file `./tsconfig.json` is set as default value in the parser configuration. If this is not the case, this must be changed accordingly:
 
 ```js
 import boehringer from '@boehringer-ingelheim/eslint-config';
 
-export default boehringer.config(
-  boehringer.configs.base,
-  {
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.dev.json'],
+export default boehringer.config(boehringer.configs.base, {
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        defaultProject: ['./tsconfig.dev.json'],
       },
     },
-  }
-);
+  },
+});
 ```
 
 ### Local

--- a/configs/base.js
+++ b/configs/base.js
@@ -22,7 +22,7 @@ module.exports = tseslint.config(
     languageOptions: {
       parserOptions: {
         // find the tsconfig.json nearest each source file
-        project: true,
+        projectService: true,
       },
     },
     linterOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@boehringer-ingelheim/eslint-config",
-  "version": "7.0.0-next.2",
+  "version": "7.0.0-typescript-eslint-parser-options.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@boehringer-ingelheim/eslint-config",
-      "version": "7.0.0-next.2",
+      "version": "7.0.0-typescript-eslint-parser-options.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boehringer-ingelheim/eslint-config",
-  "version": "7.0.0-next.2",
+  "version": "7.0.0-typescript-eslint-parser-options.1",
   "description": "Shared eslint configuration used at Boehringer Ingelheim for code styling",
   "keywords": [
     "boehringer",


### PR DESCRIPTION
- following recommendation from typescript-eslint: https://typescript-eslint.io/packages/parser#project