### PR TITLE
fix(react): [sort-jsx-props] use regex pattern for custom groups

### DIFF
--- a/configs/react.js
+++ b/configs/react.js
@@ -78,8 +78,8 @@ module.exports = tseslint.config(
         'error',
         {
           customGroups: {
-            callback: 'on*',
-            reservedProps: ['children', 'dangerouslySetInnerHTML', 'key', 'ref'], // Reserved props from: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-sort-props.js#L40C12-L40C12
+            callback: '^on.+',
+            reservedProps: ['children', 'dangerouslySetInnerHTML', 'key', 'ref'], // Reserved props from: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-sort-props.js#L41-L46
           },
           groups: ['reservedProps', 'unknown', 'callback'],
           ignoreCase: true,


### PR DESCRIPTION
- with eslint-plugin-perfectionist@4 the support of glob pattern was removed in favor of regex which leads to unintended sorting of the props, see: https://github.com/azat-io/eslint-plugin-perfectionist/releases/tag/v4.0.0