### PR TITLE
feat(playwright): disable unbound-method rule for component testing compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [7.2.0-support-playwright-ct.1](https://github.com/Boehringer-Ingelheim/eslint-config/compare/v7.1.0...v7.2.0-support-playwright-ct.1) (2025-02-14)
+
+
+### Features
+
+* **playwright:** disable unbound-method rule for component testing compatibility ([47349c9](https://github.com/Boehringer-Ingelheim/eslint-config/commit/47349c9c9eae8ec6d93e6da51fd62acf3359a12a))
+
 # [7.1.0](https://github.com/Boehringer-Ingelheim/eslint-config/compare/v7.0.0...v7.1.0) (2025-02-04)
 
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ export default boehringer.config(
 );
 ```
 
+or for specific files only:
+
+```js
+import boehringer from '@boehringer-ingelheim/eslint-config';
+
+export default boehringer.config(
+  boehringer.configs.strict,
+  {
+    files: ['src/**/*.test.{ts,tsx}'],
+    ...(await boehringer.configs.playwright)[0],
+  },
+);
+```
+
 This shared ESLint configuration is designed to enforce best practices and recommendations when writing tests with Playwright. It extends the [`eslint-plugin-playwright`](https://github.com/playwright-community/eslint-plugin-playwright) configuration and adds the following rules:
 
 - [`playwright/prefer-to-be`](https://github.com/playwright-community/eslint-plugin-playwright/blob/main/docs/rules/prefer-to-be.md): enforces the use of `.toBe()` instead of `.toEqual()` when testing for equality.

--- a/configs/playwright.js
+++ b/configs/playwright.js
@@ -4,8 +4,21 @@ const tseslint = require('typescript-eslint');
 module.exports = tseslint.config({
   ...playwright.configs['flat/recommended'],
   rules: {
-    ...playwright.configs['flat/recommended'].rules,
+    /**
+     * At the moment, `eslint-plugin-playwright` does not fully support component testing with type information.
+     * https://github.com/playwright-community/eslint-plugin-playwright/issues/298
+     *
+     * The `mount` function is flagged as an error by the `@typescript-eslint/unbound-method` rule.
+     * But it is okay to use `mount` in this context for test files.
+     * https://typescript-eslint.io/rules/unbound-method/#when-not-to-use-it
+     *
+     * Hint: `eslint-plugin-jest` has already a customized version of this rule.
+     * https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md
+     */
+    '@typescript-eslint/unbound-method': 'off',
+
     // eslint-plugin-playwright: https://github.com/playwright-community/eslint-plugin-playwright
+    ...playwright.configs['flat/recommended'].rules,
     'playwright/prefer-to-be': 'error',
     'playwright/prefer-to-have-length': 'error',
     'playwright/require-top-level-describe': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@boehringer-ingelheim/eslint-config",
-  "version": "7.1.0",
+  "version": "7.2.0-support-playwright-ct.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@boehringer-ingelheim/eslint-config",
-      "version": "7.1.0",
+      "version": "7.2.0-support-playwright-ct.1",
       "license": "MIT",
       "dependencies": {
         "@eslint/js": "^9.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boehringer-ingelheim/eslint-config",
-  "version": "7.1.0",
+  "version": "7.2.0-support-playwright-ct.1",
   "description": "Shared eslint configuration used at Boehringer Ingelheim for code styling",
   "keywords": [
     "boehringer",


### PR DESCRIPTION
- update documentation how to use the configuration only for specific files
