### PR TITLE
Remove redundant rules

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -65,8 +65,6 @@ module.exports = tseslint.config(
       'no-unneeded-ternary': 'error',
       'no-useless-concat': 'error',
       'operator-assignment': ['error', 'never'],
-      'prefer-const': 'error',
-      'prefer-rest-params': 'error',
       'prefer-template': 'error',
       'sort-imports': 'off', // disabled due to conflict with eslint-plugin-perfectionist
       'sort-keys': 'off', // disabled due to conflict with eslint-plugin-perfectionist

--- a/configs/base.js
+++ b/configs/base.js
@@ -58,7 +58,6 @@ module.exports = tseslint.config(
       'logical-assignment-operators': ['error', 'never'],
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       'no-else-return': ['error', { allowElseIf: false }],
-      'no-empty-function': 'error',
       'no-lonely-if': 'error',
       'no-negated-condition': 'error',
       'no-nested-ternary': 'error',


### PR DESCRIPTION
- fix(base): remove redundant no-empty-function rule from base config
  this rule is implemented as a replacement in typescript-eslint and therefore also disabled in the typescript-eslint recommended config. enabling this rule again manually only leads to redundant problem messages
- refactor(base): remove redundant rules prefer-const and prefer-rest-params
  those are already configured in the recommended and stylistic configs of typescript-eslint
