### PR TITLE
feat(deps): update eslint-plugin-perfectionist to v5

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -102,6 +102,7 @@ module.exports = defineConfig(
         {
           ...perfectionist.configs['recommended-natural'].rules['perfectionist/sort-imports'][1],
           groups: SORT_IMPORTS_GROUPS,
+          newlinesBetween: 0,
         },
       ],
       'perfectionist/sort-intersection-types': [

--- a/configs/base.js
+++ b/configs/base.js
@@ -6,6 +6,7 @@ const { defineConfig } = require('eslint/config');
 const tseslint = require('typescript-eslint');
 
 const {
+  PERFECTIONIST_SETTINGS,
   SORT_CLASSES_GROUPS,
   SORT_IMPORTS_GROUPS,
   SORT_INTERSECTION_TYPES_GROUPS,
@@ -93,36 +94,31 @@ module.exports = defineConfig(
       'perfectionist/sort-classes': [
         'error',
         {
-          ...perfectionist.configs['recommended-natural'].rules['perfectionist/sort-classes'][1],
           groups: SORT_CLASSES_GROUPS,
         },
       ],
       'perfectionist/sort-imports': [
         'error',
         {
-          ...perfectionist.configs['recommended-natural'].rules['perfectionist/sort-imports'][1],
           groups: SORT_IMPORTS_GROUPS,
-          newlinesBetween: 0,
+          newlinesBetween: 0, // No newlines are allowed between groups
         },
       ],
       'perfectionist/sort-intersection-types': [
         'error',
         {
-          ...perfectionist.configs['recommended-natural'].rules['perfectionist/sort-intersection-types'][1],
           groups: SORT_INTERSECTION_TYPES_GROUPS,
         },
       ],
       'perfectionist/sort-named-imports': [
         'error',
         {
-          ...perfectionist.configs['recommended-natural'].rules['perfectionist/sort-named-imports'][1],
           ignoreAlias: true,
         },
       ],
       'perfectionist/sort-objects': [
         'error',
         {
-          ...perfectionist.configs['recommended-natural'].rules['perfectionist/sort-objects'][1],
           partitionByComment: true,
         },
       ],
@@ -130,6 +126,9 @@ module.exports = defineConfig(
     settings: {
       'import/resolver': {
         typescript: true,
+      },
+      perfectionist: {
+        ...PERFECTIONIST_SETTINGS,
       },
     },
   },

--- a/configs/base.js
+++ b/configs/base.js
@@ -102,7 +102,6 @@ module.exports = defineConfig(
         {
           ...perfectionist.configs['recommended-natural'].rules['perfectionist/sort-imports'][1],
           groups: SORT_IMPORTS_GROUPS,
-          newlinesBetween: 'ignore',
         },
       ],
       'perfectionist/sort-intersection-types': [

--- a/configs/react.js
+++ b/configs/react.js
@@ -4,8 +4,7 @@ const reactHooks = require('eslint-plugin-react-hooks');
 const reactRefresh = require('eslint-plugin-react-refresh');
 const { defineConfig } = require('eslint/config');
 const globals = require('globals');
-
-const { SORT_IMPORTS_GROUPS } = require('../lib/eslint-plugin-perfectionist.js');
+const { PERFECTIONIST_SETTINGS, SORT_IMPORTS_GROUPS } = require('../lib/eslint-plugin-perfectionist.js');
 const base = require('./base.js');
 
 module.exports = defineConfig(
@@ -67,9 +66,7 @@ module.exports = defineConfig(
             },
           ],
           groups: ['react', ...SORT_IMPORTS_GROUPS],
-          ignoreCase: true,
-          newlinesBetween: 0,
-          type: 'natural',
+          newlinesBetween: 0, // No newlines are allowed between groups
         },
       ],
       'perfectionist/sort-jsx-props': [
@@ -86,8 +83,6 @@ module.exports = defineConfig(
             },
           ],
           groups: ['reservedProps', 'unknown', 'callback'],
-          ignoreCase: true,
-          type: 'natural',
         },
       ],
 
@@ -104,6 +99,9 @@ module.exports = defineConfig(
       ],
     },
     settings: {
+      perfectionist: {
+        ...PERFECTIONIST_SETTINGS,
+      },
       react: {
         version: 'detect',
       },

--- a/configs/react.js
+++ b/configs/react.js
@@ -60,27 +60,30 @@ module.exports = defineConfig(
       'perfectionist/sort-imports': [
         'error',
         {
-          customGroups: {
-            type: {
-              react: ['react'],
+          customGroups: [
+            {
+              elementNamePattern: ['^react$'],
+              groupName: 'react',
             },
-            value: {
-              react: ['react'],
-            },
-          },
+          ],
           groups: ['react', ...SORT_IMPORTS_GROUPS],
           ignoreCase: true,
-          newlinesBetween: 'ignore',
           type: 'natural',
         },
       ],
       'perfectionist/sort-jsx-props': [
         'error',
         {
-          customGroups: {
-            callback: '^on.+',
-            reservedProps: ['children', 'dangerouslySetInnerHTML', 'key', 'ref'], // Reserved props from: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-sort-props.js#L41-L46
-          },
+          customGroups: [
+            {
+              elementNamePattern: '^on.+',
+              groupName: 'callback',
+            },
+            {
+              elementNamePattern: ['children', 'dangerouslySetInnerHTML', 'key', 'ref'], // Reserved props from: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-sort-props.js#L41-L46
+              groupName: 'reservedProps',
+            },
+          ],
           groups: ['reservedProps', 'unknown', 'callback'],
           ignoreCase: true,
           type: 'natural',

--- a/configs/react.js
+++ b/configs/react.js
@@ -68,6 +68,7 @@ module.exports = defineConfig(
           ],
           groups: ['react', ...SORT_IMPORTS_GROUPS],
           ignoreCase: true,
+          newlinesBetween: 0,
           type: 'natural',
         },
       ],

--- a/lib/eslint-plugin-perfectionist.js
+++ b/lib/eslint-plugin-perfectionist.js
@@ -5,18 +5,20 @@
  * The following group names are available for configuration: https://eslint-plugin-perfectionist.azat.io/rules/sort-imports#groups
  */
 const SORT_IMPORTS_GROUPS = [
-  ['builtin', 'builtin-type'],
-  ['external', 'external-type'],
-  ['internal', 'internal-type'],
-  ['parent', 'parent-type', 'sibling', 'sibling-type', 'index', 'index-type'],
-  'style',
-  ['side-effect-style', 'side-effect'],
-  'object',
+  ['value-builtin', 'named-type-builtin'],
+  ['value-external', 'named-type-external'],
+  ['value-internal', 'named-type-internal'],
+  ['value-parent', 'named-type-parent'],
+  ['value-sibling', 'named-type-sibling'],
+  ['value-index', 'named-type-index'],
+  'value-style',
+  ['value-side-effect-style', 'value-side-effect'],
+  'value-ts-equals-import',
   'unknown',
 ];
 
 /**
- * This is the the groups configuration of all the recommended configs by eslint-plugin-perfectionist.
+ * This is the the default groups configuration of all the recommended configs by eslint-plugin-perfectionist.
  * This array can be used to reconfigure some options of the perfectionist/sort-classes rule without
  * overwriting the groups configuration of this rule.
  * This config can be found here:
@@ -25,19 +27,31 @@ const SORT_IMPORTS_GROUPS = [
  */
 const SORT_CLASSES_GROUPS = [
   'index-signature',
-  'static-property',
-  'private-property',
-  'property',
-  'constructor',
-  'static-method',
-  'private-method',
-  'method',
+  ['static-property', 'static-accessor-property'],
+  ['static-get-method', 'static-set-method'],
+  ['protected-static-property', 'protected-static-accessor-property'],
+  ['protected-static-get-method', 'protected-static-set-method'],
+  ['private-static-property', 'private-static-accessor-property'],
+  ['private-static-get-method', 'private-static-set-method'],
+  'static-block',
+  ['property', 'accessor-property'],
   ['get-method', 'set-method'],
+  ['protected-property', 'protected-accessor-property'],
+  ['protected-get-method', 'protected-set-method'],
+  ['private-property', 'private-accessor-property'],
+  ['private-get-method', 'private-set-method'],
+  'constructor',
+  ['static-method', 'static-function-property'],
+  ['protected-static-method', 'protected-static-function-property'],
+  ['private-static-method', 'private-static-function-property'],
+  ['method', 'function-property'],
+  ['protected-method', 'protected-function-property'],
+  ['private-method', 'private-function-property'],
   'unknown',
 ];
 
 /**
- * This array can be used to configure the perfectionist/sort-intersection-types rule.
+ * Customized configuration to configure the perfectionist/sort-intersection-types rule.
  * The following group names are available for configuration: https://perfectionist.dev/rules/sort-intersection-types#groups
  */
 const SORT_INTERSECTION_TYPES_GROUPS = [

--- a/lib/eslint-plugin-perfectionist.js
+++ b/lib/eslint-plugin-perfectionist.js
@@ -1,4 +1,13 @@
 /**
+ * Opinionated 'default' settings for eslint-plugin-perfectionist.
+ * @see https://perfectionist.dev/guide/getting-started#settings
+ */
+const PERFECTIONIST_SETTINGS = {
+  ignoreCase: true, // Ignore case when sorting
+  type: 'natural',
+};
+
+/**
  * While the sorting of imports is done by `eslint-plugin-perfectionist/sort-imports`,
  * the order and grouping of imports is still taken from the previous configuration of `eslint-plugin-import/order`,
  * as it feels more natural.
@@ -71,6 +80,7 @@ const SORT_INTERSECTION_TYPES_GROUPS = [
 ];
 
 module.exports = {
+  PERFECTIONIST_SETTINGS,
   SORT_CLASSES_GROUPS,
   SORT_IMPORTS_GROUPS,
   SORT_INTERSECTION_TYPES_GROUPS,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-perfectionist": "^4.15.1",
+        "eslint-plugin-perfectionist": "^5.3.1",
         "eslint-plugin-playwright": "^2.4.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -41,14 +41,14 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-oBfqT3GwkvLlo1fjvhQLQxuwZCGTarTE5OuZ2Wg10hvhBj7LRIlF611WT4aZS6fDhO5ZKlY7lCAZTlpmyaHaeg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.2.tgz",
+      "integrity": "sha512-Ast1V7yHbGAhplAsuVlnb/5J8Mtr/Zl6byPPL+Qjq3lmfIgWF1ak1iYfF/079cRERiuTALTXkSuEUdZeDCfGtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/exec": "^2.0.0",
-        "@actions/http-client": "^3.0.0"
+        "@actions/http-client": "^3.0.1"
       }
     },
     "node_modules/@actions/exec": {
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.0.tgz",
-      "integrity": "sha512-1s3tXAfVMSz9a4ZEBkXXRQD4QhY3+GAsWSbaYpeknPOKEeyRiU3lH+bHiLMZdo2x/fIeQ/hscL1wCkDLVM2DZQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.1.tgz",
+      "integrity": "sha512-SbGS8c/vySbNO3kjFgSW77n83C4MQx/Yoe+b1hAdpuvfHxnkHzDq2pWljUpAA56Si1Gae/7zjeZsV0CYjmLo/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -390,32 +390,60 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.2.0.tgz",
-      "integrity": "sha512-SQCBGsL9MFk8utWNSthdxd9iOD1pIVZSHxGBwYIGfd67RTjxqzFOSAYeQVXOu3IxRC3YrTOH37ThnTLjUlyF2w==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.3.1.tgz",
+      "integrity": "sha512-ErVLC/IsHhcvxCyh+FXo7jy12/nkQySjWXYgCoQbZLkFp4hysov8KS6CdxBB0cWjbZWjvNOKBMNoUVqkmGmahw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.2.0",
+        "@commitlint/types": "^20.3.1",
         "ajv": "^8.11.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/ensure": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.2.0.tgz",
-      "integrity": "sha512-+8TgIGv89rOWyt3eC6lcR1H7hqChAKkpawytlq9P1i/HYugFRVqgoKJ8dhd89fMnlrQTLjA5E97/4sF09QwdoA==",
+    "node_modules/@commitlint/config-validator/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.2.0",
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/ensure": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.3.1.tgz",
+      "integrity": "sha512-h664FngOEd7bHAm0j8MEKq+qm2mH+V+hwJiIE2bWcw3pzJMlO0TPKtk0ATyRAtV6jQw+xviRYiIjjSjfajiB5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/types": "^20.3.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.snakecase": "^4.1.1",
         "lodash.startcase": "^4.4.0",
         "lodash.upperfirst": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/ensure/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
       },
       "engines": {
         "node": ">=v18"
@@ -432,13 +460,27 @@
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.2.0.tgz",
-      "integrity": "sha512-PhNoLNhxpfIBlW/i90uZ3yG3hwSSYx7n4d9Yc+2FAorAHS0D9btYRK4ZZXX+Gm3W5tDtu911ow/eWRfcRVgNWg==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.3.1.tgz",
+      "integrity": "sha512-jfsjGPFTd2Yti2YHwUH4SPRPbWKAJAwrfa3eNa9bXEdrXBb9mCwbIrgYX38LdEJK9zLJ3AsLBP4/FLEtxyu2AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.2.0",
+        "@commitlint/types": "^20.3.1",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/format/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
         "chalk": "^5.3.0"
       },
       "engines": {
@@ -446,52 +488,94 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.2.0.tgz",
-      "integrity": "sha512-Lz0OGeZCo/QHUDLx5LmZc0EocwanneYJUM8z0bfWexArk62HKMLfLIodwXuKTO5y0s6ddXaTexrYHs7v96EOmw==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.3.1.tgz",
+      "integrity": "sha512-tWwAoh93QvAhxgp99CzCuHD86MgxE4NBtloKX+XxQxhfhSwHo7eloiar/yzx53YW9eqSLP95zgW2KDDk4/WX+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.2.0",
+        "@commitlint/types": "^20.3.1",
         "semver": "^7.6.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/lint": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.3.0.tgz",
-      "integrity": "sha512-X19HOGU5nRo6i9DIY0kG0mhgtvpn1UGO1D6aLX1ILLyeqSM5yJyMcrRqNj8SLgeSeUDODhLY9QYsBIG0LdNHkA==",
+    "node_modules/@commitlint/is-ignored/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^20.2.0",
-        "@commitlint/parse": "^20.2.0",
-        "@commitlint/rules": "^20.3.0",
-        "@commitlint/types": "^20.2.0"
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/lint": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.3.1.tgz",
+      "integrity": "sha512-LaOtrQ24+6SfUaWg8A+a+Wc77bvLbO5RIr6iy9F7CI3/0iq1uPEWgGRCwqWTuLGHkZDAcwaq0gZ01zpwZ1jCGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/is-ignored": "^20.3.1",
+        "@commitlint/parse": "^20.3.1",
+        "@commitlint/rules": "^20.3.1",
+        "@commitlint/types": "^20.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/lint/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
       },
       "engines": {
         "node": ">=v18"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.3.0.tgz",
-      "integrity": "sha512-amkdVZTXp5R65bsRXRSCwoNXbJHR2aAIY/RGFkoyd63t8UEwqEgT3f0MgeLqYw4hwXyq+TYXKdaW133E29pnGQ==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.3.1.tgz",
+      "integrity": "sha512-YDD9XA2XhgYgbjju8itZ/weIvOOobApDqwlPYCX5NLO/cPtw2UMO5Cmn44Ks8RQULUVI5fUT6roKvyxcoLbNmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.2.0",
+        "@commitlint/config-validator": "^20.3.1",
         "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.2.0",
-        "@commitlint/types": "^20.2.0",
+        "@commitlint/resolve-extends": "^20.3.1",
+        "@commitlint/types": "^20.3.1",
         "chalk": "^5.3.0",
         "cosmiconfig": "^9.0.0",
         "cosmiconfig-typescript-loader": "^6.1.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.uniq": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
       },
       "engines": {
         "node": ">=v18"
@@ -508,13 +592,13 @@
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.2.0.tgz",
-      "integrity": "sha512-LXStagGU1ivh07X7sM+hnEr4BvzFYn1iBJ6DRg2QsIN8lBfSzyvkUcVCDwok9Ia4PWiEgei5HQjju6xfJ1YaSQ==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.3.1.tgz",
+      "integrity": "sha512-TuUTdbLpyUNLgDzLDYlI2BeTE6V/COZbf3f8WwsV0K6eq/2nSpNTMw7wHtXb+YxeY9wwxBp/Ldad4P+YIxHJoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.2.0",
+        "@commitlint/types": "^20.3.1",
         "conventional-changelog-angular": "^7.0.0",
         "conventional-commits-parser": "^5.0.0"
       },
@@ -522,15 +606,29 @@
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/parse/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
     "node_modules/@commitlint/read": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.2.0.tgz",
-      "integrity": "sha512-+SjF9mxm5JCbe+8grOpXCXMMRzAnE0WWijhhtasdrpJoAFJYd5UgRTj/oCq5W3HJTwbvTOsijEJ0SUGImECD7Q==",
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.3.1.tgz",
+      "integrity": "sha512-nCmJAdIg3OdNVUpQW0Idk/eF/vfOo2W2xzmvRmNeptLrzFK7qhwwl/kIwy1Q1LZrKHUFNj7PGNpIT5INbgZWzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@commitlint/top-level": "^20.0.0",
-        "@commitlint/types": "^20.2.0",
+        "@commitlint/types": "^20.3.1",
         "git-raw-commits": "^4.0.0",
         "minimist": "^1.2.8",
         "tinyexec": "^1.0.0"
@@ -539,15 +637,29 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/resolve-extends": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.2.0.tgz",
-      "integrity": "sha512-KVoLDi9BEuqeq+G0wRABn4azLRiCC22/YHR2aCquwx6bzCHAIN8hMt3Nuf1VFxq/c8ai6s8qBxE8+ZD4HeFTlQ==",
+    "node_modules/@commitlint/read/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.2.0",
-        "@commitlint/types": "^20.2.0",
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.3.1.tgz",
+      "integrity": "sha512-iGTGeyaoDyHDEZNjD8rKeosjSNs8zYanmuowY4ful7kFI0dnY4b5QilVYaFQJ6IM27S57LAeH5sKSsOHy4bw5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/config-validator": "^20.3.1",
+        "@commitlint/types": "^20.3.1",
         "global-directory": "^4.0.1",
         "import-meta-resolve": "^4.0.0",
         "lodash.mergewith": "^4.6.2",
@@ -557,17 +669,45 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/rules": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.3.0.tgz",
-      "integrity": "sha512-TGgXN/qBEhbzVD13crE1l7YSMJRrbPbUL0OBZALbUM5ER36RZmiZRu2ud2W/AA7HO9YLBRbyx6YVi2t/2Be0yQ==",
+    "node_modules/@commitlint/resolve-extends/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^20.2.0",
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/rules": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.3.1.tgz",
+      "integrity": "sha512-/uic4P+4jVNpqQxz02+Y6vvIC0A2J899DBztA1j6q3f3MOKwydlNrojSh0dQmGDxxT1bXByiRtDhgFnOFnM6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@commitlint/ensure": "^20.3.1",
         "@commitlint/message": "^20.0.0",
         "@commitlint/to-lines": "^20.0.0",
-        "@commitlint/types": "^20.2.0"
+        "@commitlint/types": "^20.3.1"
+      },
+      "engines": {
+        "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/rules/node_modules/@commitlint/types": {
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.3.1.tgz",
+      "integrity": "sha512-VmIFV/JkBRhDRRv7N5B7zEUkNZIx9Mp+8Pe65erz0rKycXLsi8Epcw0XJ+btSeRXgTzE7DyOyA9bkJ9mn/yqVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/conventional-commits-parser": "^5.0.0",
+        "chalk": "^5.3.0"
       },
       "engines": {
         "node": ">=v18"
@@ -2477,9 +2617,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "version": "2.9.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.13.tgz",
+      "integrity": "sha512-WhtvB2NG2wjr04+h77sg3klAIwrgOqnjS49GGudnUPGFFgg7G17y7Qecqp+2Dr5kUDxNRBca0SK7cG8JwzkWDQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -2633,9 +2773,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001762",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
-      "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
+      "version": "1.0.30001763",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001763.tgz",
+      "integrity": "sha512-mh/dGtq56uN98LlNX9qdbKnzINhX0QzhiWBFEkFfsFO4QyCvL8YegrJAazCwXIeqkIob8BlZPGM3xdnY+sgmvQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3961,17 +4101,16 @@
       }
     },
     "node_modules/eslint-plugin-perfectionist": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-4.15.1.tgz",
-      "integrity": "sha512-MHF0cBoOG0XyBf7G0EAFCuJJu4I18wy0zAoT1OHfx2o6EOx1EFTIzr2HGeuZa1kDcusoX0xJ9V7oZmaeFd773Q==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.3.1.tgz",
+      "integrity": "sha512-v8kAP8TarQYqDC4kxr343ZNi++/oOlBnmWovsUZpbJ7A/pq1VHGlgsf/fDh4CdEvEstzkrc8NLvoVKtfpsC4oA==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.38.0",
-        "@typescript-eslint/utils": "^8.38.0",
+        "@typescript-eslint/utils": "^8.52.0",
         "natural-orderby": "^5.0.0"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.0.0 || >=22.0.0"
       },
       "peerDependencies": {
         "eslint": ">=8.45.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "eslint-plugin-perfectionist": "^4.15.1",
+    "eslint-plugin-perfectionist": "^5.3.1",
     "eslint-plugin-playwright": "^2.4.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",


### PR DESCRIPTION
- bump package eslint-plugin-perfectionist from ^4.15.1 to ^5.3.1
- migrate configuration of eslint-plugin-perfectionist
- update `perfectionist/sort-imports` configuration to not allow newlines between imports