### PR TITLE
build: add min-release-age and package-lock to npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,4 +4,14 @@
 
 # Publish Configuration: https://docs.npmjs.com/cli/v11/commands/npm-publish#configuration
 access=public
+# Disable scripts to prevent potential security risks from running untrusted code during installation
+# TODO we should enable this once we switched from husky to config-based hooks
+# ignore-scripts=true
+# Quarantine window — refuse to install any package version published less than 7 days ago. Most supply-chain attacks (typosquatting, account takeover)
+# are detected by the community within hours; a 7-day buffer eliminates the
+# majority of the risk.
+min-release-age=7
+# Always use package-lock.json to ensure consistent installs across environments
+package-lock=true
+# Enable package provenance to verify the integrity and authenticity of packages, providing an additional layer of security against supply-chain attacks.
 provenance=true


### PR DESCRIPTION
min-release-age is changing the config to 7 days
package-lock is set to its default to ensure it is not reconfigured