### PR TITLE
Loosen sonar rules

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -21,7 +21,6 @@ export default defineConfig(includeIgnoreFile(), strict, {
         partitionByComment: true,
       },
     ],
-    'sonarjs/todo-tag': 'warn',
     'sort-keys': 'off', // disabled due to conflict with eslint-plugin-perfectionist
   },
 });

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -121,6 +121,9 @@ export default defineConfig(
           partitionByComment: true,
         },
       ],
+
+      // eslint-plugin-sonarjs: https://github.com/SonarSource/SonarJS/blob/master/packages/analysis/src/jsts/rules/README.md
+      'sonarjs/todo-tag': 'warn',
     },
     settings: {
       'import/resolver': {

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -123,8 +123,9 @@ export default defineConfig(
       ],
 
       // eslint-plugin-sonarjs: https://github.com/SonarSource/SonarJS/blob/master/packages/analysis/src/jsts/rules/README.md
-      'sonarjs/todo-tag': 'warn',
+      'sonarjs/deprecation': 'off', // disable rule in favor of @typescript-eslint/no-deprecated
       'sonarjs/no-unused-vars': 'off', // disabled due to overlap with @typescript-eslint/no-unused-vars
+      'sonarjs/todo-tag': 'warn',
     },
     settings: {
       'import/resolver': {

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -4,6 +4,7 @@ import perfectionist from 'eslint-plugin-perfectionist';
 import { configs as sonarjsConfigs } from 'eslint-plugin-sonarjs';
 import { defineConfig } from 'eslint/config';
 import tseslint from 'typescript-eslint';
+import { TEST_FILE_GLOBS } from '../lib/constants.js';
 import {
   PERFECTIONIST_SETTINGS,
   SORT_CLASSES_GROUPS,
@@ -139,11 +140,19 @@ export default defineConfig(
   {
     files: [
       '**/*.d.ts', // TypeScript declaration files
-      '**/*.{spec,test}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}', // Usually test files
+      ...TEST_FILE_GLOBS,
       './*.{js,cjs,mjs,ts,cts,mts}', // Mostly configuration files on root level
     ],
     rules: {
       'import/no-unused-modules': 'off',
+    },
+  },
+  {
+    files: [...TEST_FILE_GLOBS],
+    rules: {
+      // eslint-plugin-sonarjs: https://github.com/SonarSource/SonarJS/blob/master/packages/analysis/src/jsts/rules/README.md
+      'sonarjs/no-duplicate-string': 'off',
+      'sonarjs/slow-regex': 'off',
     },
   },
 );

--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -124,6 +124,7 @@ export default defineConfig(
 
       // eslint-plugin-sonarjs: https://github.com/SonarSource/SonarJS/blob/master/packages/analysis/src/jsts/rules/README.md
       'sonarjs/todo-tag': 'warn',
+      'sonarjs/no-unused-vars': 'off', // disabled due to overlap with @typescript-eslint/no-unused-vars
     },
     settings: {
       'import/resolver': {

--- a/src/configs/playwright.ts
+++ b/src/configs/playwright.ts
@@ -30,5 +30,9 @@ export default defineConfig({
     'playwright/prefer-to-be': 'error',
     'playwright/prefer-to-have-length': 'error',
     'playwright/require-top-level-describe': 'error',
+
+    // eslint-plugin-sonarjs: https://github.com/SonarSource/SonarJS/blob/master/packages/analysis/src/jsts/rules/README.md
+    'sonarjs/no-duplicate-string': 'off',
+    'sonarjs/slow-regex': 'off',
   },
 });

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const TEST_FILE_GLOBS = ['**/*.{spec,test}.{js,cjs,mjs,jsx,ts,cts,mts,tsx}', '**/__tests__/**'] as const;


### PR DESCRIPTION
- feat(base): set sonars todo-tag rule to warn
- feat(base): disables sonarjs/no-unused-vars in favor of @typescript-eslint/no-unused-vars
