### PR TITLE
Enable manual dispatches in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,18 @@
+name: Setup
+description: Checkout, setup Node, and install dependencies
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v6
+      with:
+        cache: npm
+        node-version-file: .nvmrc
+        registry-url: https://registry.npmjs.org/
+    - name: Install Dependencies
+      shell: bash
+      run: npm clean-install
+    - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
+      run: npm audit signatures

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,18 +24,7 @@ jobs:
     name: Test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v6
-        with:
-          cache: npm
-          node-version-file: '.nvmrc'
-          registry-url: https://registry.npmjs.org/
-      - name: Install Dependencies
-        run: npm clean-install
-      - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
-        run: npm audit signatures
+      - uses: ./.github/actions/setup
       - name: Lint the project
         run: npm run lint
       - name: Run tests
@@ -46,16 +35,7 @@ jobs:
     needs: test
     if: ${{ inputs.dryRun }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v6
-        with:
-          cache: npm
-          node-version-file: '.nvmrc'
-          registry-url: https://registry.npmjs.org/
-      - name: Install Dependencies
-        run: npm clean-install
+      - uses: ./.github/actions/setup
       - name: Build the project
         run: npm run build
       - name: Run release as a dry run
@@ -71,16 +51,7 @@ jobs:
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v6
-        with:
-          cache: npm
-          node-version-file: '.nvmrc'
-          registry-url: https://registry.npmjs.org/
-      - name: Install Dependencies
-        run: npm clean-install
+      - uses: ./.github/actions/setup
       - name: Build the project
         run: npm run build
       - name: Release package to npm and GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,28 @@
-name: Release
+name: test, build and release
 
 on:
   push:
     branches:
       - master
       - next
-      - feature/**
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Run release as a dry run'
+        required: false
+        default: true
 
 permissions:
   contents: read # for checkout
 
+env:
+  # Disable husky (git hooks) in CI, see: https://typicode.github.io/husky/#/?id=disable-husky-in-cidocker
+  HUSKY: 0
+
 jobs:
-  release:
-    env:
-      # Disable husky (git hooks) in CI, see: https://typicode.github.io/husky/#/?id=disable-husky-in-cidocker
-      HUSKY: 0
-    name: Release
+  test:
+    name: Test
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - uses: actions/checkout@v6
         with:
@@ -39,6 +40,47 @@ jobs:
         run: npm run lint
       - name: Run tests
         run: npm run test:ci
+  releaseDryRun:
+    name: Release Dry Run
+    runs-on: ubuntu-24.04
+    needs: test
+    if: github.event_name == 'workflow_dispatch' && inputs.dryRun == true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version-file: '.nvmrc'
+          registry-url: https://registry.npmjs.org/
+      - name: Install Dependencies
+        run: npm clean-install
+      - name: Build the project
+        run: npm run build
+      - name: Run release as a dry run
+        run: npm run release -- --dry-run
+  release:
+    name: Release
+    runs-on: ubuntu-24.04
+    needs: test
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dryRun == false)
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version-file: '.nvmrc'
+          registry-url: https://registry.npmjs.org/
+      - name: Install Dependencies
+        run: npm clean-install
       - name: Build the project
         run: npm run build
       - name: Release package to npm and GitHub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     name: Release Dry Run
     runs-on: ubuntu-24.04
     needs: test
-    if: github.event_name == 'workflow_dispatch' && inputs.dryRun == true
+    if: ${{ inputs.dryRun }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -64,7 +64,7 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     needs: test
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dryRun == false)
+    if: ${{ !inputs.dryRun }}
     permissions:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues


### PR DESCRIPTION
- splits job to ensure tests and dry runs are run without write permissions
- introduces manual workflow_dispatch
- introduces dry run release and non-dry-runs for pushes on master and next and selection for manual trigger